### PR TITLE
display-mappings-in-crawlers

### DIFF
--- a/dataPipelines/gc_crawler/data_model.py
+++ b/dataPipelines/gc_crawler/data_model.py
@@ -38,7 +38,8 @@ class DownloadableItem:
     @staticmethod
     def from_dict(obj_dict: Dict[Any, Any]) -> 'DownloadableItem':
         """Deserialize DownloadableItem object from plain dictionary"""
-        _obj_dict = copy.deepcopy(obj_dict)  # avoid problems with arrays and other ref types
+        _obj_dict = copy.deepcopy(
+            obj_dict)  # avoid problems with arrays and other ref types
         return DownloadableItem(**_obj_dict)
 
 
@@ -65,6 +66,9 @@ class Document:
         doc_title: str,
         doc_num: str,
         doc_type: str,
+        display_doc_type: str,
+        display_org: str,
+        display_source: str,
         publication_date: str,
         cac_login_required: bool,
         crawler_used: str,
@@ -74,7 +78,7 @@ class Document:
         original_publication_date: Optional[str] = None,
         access_timestamp: datetime = datetime.now(),
         source_fqdn: Optional[str] = None,
-        version_hash: Optional[str] = None
+        version_hash: Optional[str] = None,
     ):
         self.doc_name = doc_name
         self.doc_title = doc_title
@@ -88,8 +92,13 @@ class Document:
         self.downloadable_items = downloadable_items
         self.version_hash_raw_data = version_hash_raw_data
         self.access_timestamp = access_timestamp
-        self.source_fqdn = source_fqdn or get_fqdn_from_web_url(self.source_page_url)
-        self.version_hash = version_hash or dict_to_sha256_hex_digest(version_hash_raw_data)
+        self.source_fqdn = source_fqdn or get_fqdn_from_web_url(
+            self.source_page_url)
+        self.version_hash = version_hash or dict_to_sha256_hex_digest(
+            version_hash_raw_data)
+        self.display_doc_type = display_doc_type
+        self.display_org = display_org
+        self.display_source = display_source
 
     def to_dict(self) -> Dict[str, Any]:
         """Plain dictionary representation"""
@@ -115,7 +124,8 @@ class Document:
     @staticmethod
     def from_dict(obj_dict: Dict[Any, Any]) -> 'Document':
         """Deserialize Document object from plain dictionary"""
-        _obj_dict = copy.deepcopy(obj_dict)  # avoid problems with arrays and other ref types
+        _obj_dict = copy.deepcopy(
+            obj_dict)  # avoid problems with arrays and other ref types
 
         downloadable_items = [
             DownloadableItem.from_dict(item) for item in _obj_dict['downloadable_items']

--- a/dataPipelines/gc_scrapy/gc_scrapy/items.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/items.py
@@ -25,3 +25,6 @@ class DocItem(scrapy.Item):
     access_timestamp = scrapy.Field()
     source_fqdn = scrapy.Field()
     version_hash = scrapy.Field()
+    display_doc_type = scrapy.Field()
+    display_org = scrapy.Field()
+    display_source = scrapy.Field()

--- a/dataPipelines/gc_scrapy/gc_scrapy/output_spec.json
+++ b/dataPipelines/gc_scrapy/gc_scrapy/output_spec.json
@@ -1,178 +1,221 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema",
-  "type": "object",
-  "title": "GameChanger Crawler Output Schema",
-  "description": "Output schema for arguments used to invoke GC crawler.",
-  "examples": [
-    {
-      "doc_name": "Misc Publication, Volume 4",
-      "source_page_url": "https://example.local/page_2.html",
-      "downloadable_items": [
-        {
-          "doc_type": "pdf",
-          "web_url": "https://example.local/pubs/misc_pub_vol4.pdf",
-          "compression_type": null
-        },
-        {
-          "doc_type": "xml",
-          "web_url": "https://example.local/pubs/misc_pub_vol4.xml",
-          "compression_type": null
-        }
-      ],
-      "version_hash_raw_data": {
-        "pub_date": "2020-06-01"
-      },
-      "access_timestamp": "2020-06-28 22:59:57.274200",
-      "source_fqdn": "example.local"
-    }
-  ],
-  "required": [
-    "doc_name",
-    "source_page_url",
-    "downloadable_items",
-    "version_hash_raw_data",
-    "access_timestamp",
-    "source_fqdn",
-    "doc_type",
-    "doc_num",
-    "doc_title",
-    "publication_date",
-    "cac_login_required",
-    "crawler_used"
-  ],
-  "properties": {
-    "doc_type": {
-      "type": "string",
-      "title": "Document Type",
-      "description": "Document Publication Type.",
-      "examples": [
-        "Title"
-      ]
-    },
-    "doc_num": {
-      "type": "string",
-      "title": "Document Number",
-      "description": "Document Number",
-      "examples": [
-        "20.4"
-      ]
-    },
-    "doc_title": {
-      "type": "string",
-      "title": "Document Title",
-      "description": "Full document title - sometimes different from doc_name",
-      "examples": [
-        "Misc Publication, Volume 4"
-      ]
-    },
-    "doc_name": {
-      "type": "string",
-	  "minLength": 1,
-      "title": "Document Name",
-      "description": "Document Name as derived from source context.",
-      "examples": [
-        "Misc Publication, Volume 4"
-      ]
-    },
-    "publication_date": {
-      "type": ["string", "null"],
-      "title": "Publication Date",
-      "description": "Date the publication was published",
-      "examples": ["01/20/2020"],
-      "default": null
-    },
-    "cac_login_required": {
-      "type": "boolean",
-      "title": "Restricted Document",
-      "description": "Access level of the document derived from context"
-    },
-    "crawler_used": {
-      "type": "string",
-      "title": "Crawler Used",
-      "description": "Name of the crawler the scraped the data"
-    },
-    "source_page_url": {
-      "type": "string",
-      "title": "Source Page URL",
-      "description": "URL at which the document links and other context was found.",
-      "examples": [
-        "https://example.local/page_2.html"
-      ],
-      "pattern": "^https?://\\S+$"
-    },
-    "downloadable_items": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/downloadable_item"
-      },
-      "minItems": 1
-    },
-    "version_hash_raw_data": {
-      "type": "object",
-      "title": "The version_hash_raw_data schema",
-      "description": "An explanation about the purpose of this instance.",
-      "examples": [
-        {
-          "pub_date": "2020-06-01"
-        }
-      ]
-    },
-    "access_timestamp": {
-      "type": "string",
-      "title": "The access_timestamp schema",
-      "description": "An explanation about the purpose of this instance.",
-      "examples": [
-        "2020-06-28 22:59:57.274200"
-      ],
-      "pattern": "\\d{4}-\\d{2}-\\d{2}[ ]\\d{2}:\\d{2}:\\d{2}[.]\\d+"
-    },
-    "source_fqdn": {
-      "type": "string",
-      "title": "Source FQDN",
-      "description": "Fully-qualified domain name of the website where document links were located.",
-      "examples": [
-        "example.local"
-      ]
-    }
-  },
-  "definitions": {
-    "downloadable_item": {
-      "type": "object",
-      "title": "Downloadable Item",
-      "description": "Downloadable item that's a part or whole of the larger document",
-      "examples": [
-        {
-          "doc_type": "pdf",
-          "web_url": "https://example.local/pubs/misc_pub_vol4.pdf",
-          "compression_type": null
-        }
-      ],
-      "required": [
-        "doc_type",
-        "web_url",
-        "compression_type"
-      ],
-      "properties": {
-        "doc_type": {
-          "type": "string",
-          "title": "Document Type",
-          "description": "The ultimate document file type when decompressed",
-          "pattern": "^[\\S]+$"
-        },
-        "web_url": {
-          "type": "string",
-          "title": "Web Url",
-          "description": "Web url to a downloadable artifact, compressed or not",
-          "pattern": "^https?://\\S+$"
-        },
-        "compression_type": {
-          "type": ["string","null"],
-          "title": "Compression Type",
-          "description": "Compression type of the downloaded artifact.",
-          "enum" : [null, "tar", "tar.gz", "tar.bz", "zip"],
-          "default": null
-        }
-      }
-    }
-  }
+	"$schema": "http://json-schema.org/draft-07/schema",
+	"type": "object",
+	"title": "GameChanger Crawler Output Schema",
+	"description": "Output schema for arguments used to invoke GC crawler.",
+	"examples": [
+		{
+			"doc_name": "Misc Publication, Volume 4",
+			"source_page_url": "https://example.local/page_2.html",
+			"downloadable_items": [
+				{
+					"doc_type": "pdf",
+					"web_url": "https://example.local/pubs/misc_pub_vol4.pdf",
+					"compression_type": null
+				},
+				{
+					"doc_type": "xml",
+					"web_url": "https://example.local/pubs/misc_pub_vol4.xml",
+					"compression_type": null
+				}
+			],
+			"version_hash_raw_data": {
+				"pub_date": "2020-06-01"
+			},
+			"access_timestamp": "2020-06-28 22:59:57.274200",
+			"source_fqdn": "example.local"
+		}
+	],
+	"required": [
+		"doc_name",
+		"source_page_url",
+		"downloadable_items",
+		"version_hash_raw_data",
+		"access_timestamp",
+		"source_fqdn",
+		"doc_type",
+		"doc_num",
+		"doc_title",
+		"publication_date",
+		"cac_login_required",
+		"crawler_used"
+	],
+	"properties": {
+		"doc_type": {
+			"type": "string",
+			"title": "Document Type",
+			"description": "Document Publication Type.",
+			"examples": [
+				"Title"
+			]
+		},
+		"display_doc_type": {
+			"type": "string",
+			"title": "Document Display Type",
+			"description": "Document Type to show on front end",
+			"examples": [
+				"Issuance",
+				"Notice",
+				"CFR Index",
+				"Legislation"
+			]
+		},
+		"display_org": {
+			"type": "string",
+			"title": "Display Org",
+			"description": "Organization to show on front end",
+			"examples": [
+				"Dept. of the Air Force",
+				"Congress"
+			]
+		},
+		"display_source": {
+			"type": "string",
+			"title": "Display Source",
+			"description": "Source to show on front end",
+			"examples": [
+				"WHS DoD Directives Division",
+				"Joint Chiefs of Staff Library"
+			]		
+		},
+		"doc_num": {
+			"type": "string",
+			"title": "Document Number",
+			"description": "Document Number",
+			"examples": [
+				"20.4"
+			]
+		},
+		"doc_title": {
+			"type": "string",
+			"title": "Document Title",
+			"description": "Full document title - sometimes different from doc_name",
+			"examples": [
+				"Misc Publication, Volume 4"
+			]
+		},
+		"doc_name": {
+			"type": "string",
+			"minLength": 1,
+			"title": "Document Name",
+			"description": "Document Name as derived from source context.",
+			"examples": [
+				"Misc Publication, Volume 4"
+			]
+		},
+		"publication_date": {
+			"type": [
+				"string",
+				"null"
+			],
+			"title": "Publication Date",
+			"description": "Date the publication was published",
+			"examples": [
+				"01/20/2020"
+			],
+			"default": null
+		},
+		"cac_login_required": {
+			"type": "boolean",
+			"title": "Restricted Document",
+			"description": "Access level of the document derived from context"
+		},
+		"crawler_used": {
+			"type": "string",
+			"title": "Crawler Used",
+			"description": "Name of the crawler the scraped the data"
+		},
+		"source_page_url": {
+			"type": "string",
+			"title": "Source Page URL",
+			"description": "URL at which the document links and other context was found.",
+			"examples": [
+				"https://example.local/page_2.html"
+			],
+			"pattern": "^https?://\\S+$"
+		},
+		"downloadable_items": {
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/downloadable_item"
+			},
+			"minItems": 1
+		},
+		"version_hash_raw_data": {
+			"type": "object",
+			"title": "The version_hash_raw_data schema",
+			"description": "An explanation about the purpose of this instance.",
+			"examples": [
+				{
+					"pub_date": "2020-06-01"
+				}
+			]
+		},
+		"access_timestamp": {
+			"type": "string",
+			"title": "The access_timestamp schema",
+			"description": "An explanation about the purpose of this instance.",
+			"examples": [
+				"2020-06-28 22:59:57.274200"
+			],
+			"pattern": "\\d{4}-\\d{2}-\\d{2}[ ]\\d{2}:\\d{2}:\\d{2}[.]\\d+"
+		},
+		"source_fqdn": {
+			"type": "string",
+			"title": "Source FQDN",
+			"description": "Fully-qualified domain name of the website where document links were located.",
+			"examples": [
+				"example.local"
+			]
+		}
+	},
+	"definitions": {
+		"downloadable_item": {
+			"type": "object",
+			"title": "Downloadable Item",
+			"description": "Downloadable item that's a part or whole of the larger document",
+			"examples": [
+				{
+					"doc_type": "pdf",
+					"web_url": "https://example.local/pubs/misc_pub_vol4.pdf",
+					"compression_type": null
+				}
+			],
+			"required": [
+				"doc_type",
+				"web_url",
+				"compression_type"
+			],
+			"properties": {
+				"doc_type": {
+					"type": "string",
+					"title": "Document Type",
+					"description": "The ultimate document file type when decompressed",
+					"pattern": "^[\\S]+$"
+				},
+				"web_url": {
+					"type": "string",
+					"title": "Web Url",
+					"description": "Web url to a downloadable artifact, compressed or not",
+					"pattern": "^https?://\\S+$"
+				},
+				"compression_type": {
+					"type": [
+						"string",
+						"null"
+					],
+					"title": "Compression Type",
+					"description": "Compression type of the downloaded artifact.",
+					"enum": [
+						null,
+						"tar",
+						"tar.gz",
+						"tar.bz",
+						"zip"
+					],
+					"default": null
+				}
+			}
+		}
+	}
 }

--- a/dataPipelines/gc_scrapy/gc_scrapy/pipelines.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/pipelines.py
@@ -43,6 +43,12 @@ class DeduplicaterPipeline():
 class AdditionalFieldsPipeline:
     def process_item(self, item, spider):
 
+        if spider.display_org:
+            item["display_org"] = spider.display_org
+
+        if spider.display_source:
+            item["display_source"] = spider.display_source
+
         if item.get('crawler_used') is None:
             item['crawler_used'] = spider.name
 

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/cfr_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/cfr_spider.py
@@ -9,6 +9,9 @@ bill_version_re = re.compile(r'\((.*)\)')
 
 class CFRSpider(GCSpider):
     name = "code_of_federal_regulations"
+    display_org = "Congress"
+    display_source = "U.S. Publishing Office"
+
     cac_login_required = False
     visible_start = "https://www.govinfo.gov/app/collection/cfr"
     start_urls = [
@@ -67,6 +70,7 @@ class CFRSpider(GCSpider):
         is_index_type = "GPO-CFR-INDEX" in package_id
 
         doc_type = "CFR Index" if is_index_type else 'CFR Title'
+        display_doc_type = doc_type
         doc_title = title if is_index_type else title.title()
         doc_num = f"{title_num} Vol. {vol_num}" if vol_num else title_num
 
@@ -91,6 +95,7 @@ class CFRSpider(GCSpider):
             doc_num=doc_num,
             doc_title=doc_title,
             doc_type=doc_type,
+            display_doc_type=display_doc_type,
             publication_date=publication_date,
             source_page_url=source_page_url,
             downloadable_items=downloadable_items,


### PR DESCRIPTION
update pipeline, output spec, and data model to allow display properties to be assigned on the spider and item instead of mapping file in parsing