### PR TITLE
temporarily fixing empty doc_name_raw return

### DIFF
--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/chief_national_guard_bureau_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/chief_national_guard_bureau_spider.py
@@ -42,6 +42,7 @@ class CNGBISpider(GCSpider):
 
             doc_name_raw = row.css('td:nth-child(1) a span::text').get()
 
+            # one row returns empty for doc_name_raw, so skip that case
             if not doc_name_raw:
                 continue
 

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/chief_national_guard_bureau_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/chief_national_guard_bureau_spider.py
@@ -41,6 +41,10 @@ class CNGBISpider(GCSpider):
             ]
 
             doc_name_raw = row.css('td:nth-child(1) a span::text').get()
+
+            if not doc_name_raw:
+                continue
+
             doc_num_raw = doc_name_raw.replace('CNGBI ', '')
 
             publication_date = row.css('td:nth-child(2) span::text').get()


### PR DESCRIPTION
Temp fix for national guard crawler. one row returned empty on the name, so skipping the row