### PR TITLE
Feature/uot 120997 rpa doc hash filtering

### DIFF
--- a/rpa/README.md
+++ b/rpa/README.md
@@ -1,0 +1,4 @@
+#Usage
+
+`python -m rpa move-from-edl`
+

--- a/rpa/README.md
+++ b/rpa/README.md
@@ -1,4 +1,4 @@
-#Usage
+## Usage
 
 `python -m rpa move-from-edl`
 

--- a/rpa/__main__.py
+++ b/rpa/__main__.py
@@ -1,0 +1,3 @@
+from .cli import cli
+
+cli()

--- a/rpa/cli.py
+++ b/rpa/cli.py
@@ -1,0 +1,12 @@
+import click
+from rpa.edl_zip_mover import move_from_edl
+
+
+@click.group()
+def cli():
+    pass
+
+
+@cli.command()
+def move_from_edl():
+    move_from_edl()

--- a/rpa/cli.py
+++ b/rpa/cli.py
@@ -1,5 +1,6 @@
 import click
 from rpa.edl_zip_mover import move_zips
+from rpa.rpa_landing_zone_mover import filter_and_move
 
 
 @click.group()
@@ -10,3 +11,8 @@ def cli():
 @cli.command()
 def move_from_edl():
     move_zips()
+
+
+@cli.command()
+def filter_and_move():
+    filter_and_move()

--- a/rpa/cli.py
+++ b/rpa/cli.py
@@ -1,5 +1,5 @@
 import click
-from rpa.edl_zip_mover import move_from_edl
+from rpa.edl_zip_mover import move_zips
 
 
 @click.group()
@@ -9,4 +9,4 @@ def cli():
 
 @cli.command()
 def move_from_edl():
-    move_from_edl()
+    move_zips()

--- a/rpa/edl_zip_mover.py
+++ b/rpa/edl_zip_mover.py
@@ -17,7 +17,8 @@ source_path = f"{source_bucket}edl/sorted/gamechanger_rpa/"
 destination_path = f"{destination_bucket}bronze/gamechanger/rpa-landing-zone/"
 
 
-def move_from_edl():
+def move_zips():
+    print('move_from_edl')
     if not allowed_ids:
         print(
             'ALLOWED_IDS_CSV_STRING not set, exiting because nothing would be let through')
@@ -55,4 +56,4 @@ def move_from_edl():
 
 
 if __name__ == "__main__":
-    move_from_edl()
+    move_zips()

--- a/rpa/edl_zip_mover.py
+++ b/rpa/edl_zip_mover.py
@@ -4,7 +4,7 @@ import re
 
 allowed_ids = [
     allowed_id.strip() for allowed_id in
-    os.environ.get('ALLOWED_IDS_CSV_STRING', None).split(',')
+    os.environ.get('ALLOWED_IDS_CSV_STRING', '').split(',')
 ]
 
 idens = "|".join(allowed_ids)

--- a/rpa/edl_zip_mover.py
+++ b/rpa/edl_zip_mover.py
@@ -13,7 +13,7 @@ allowed_re = re.compile(f'.*({idens}).*')
 source_bucket = "advana-landing-zone/"
 destination_bucket = "advana-data-zone/"
 
-source_path = f"{source_bucket}edl/sorted/gamechanger_rpa/"
+source_path = f"{source_bucket}edl/non-sensitive/Gamechanger RPA/"
 destination_path = f"{destination_bucket}bronze/gamechanger/rpa-landing-zone/"
 
 

--- a/rpa/edl_zip_mover.py
+++ b/rpa/edl_zip_mover.py
@@ -18,7 +18,6 @@ destination_path = f"{destination_bucket}bronze/gamechanger/rpa-landing-zone/"
 
 
 def move_zips():
-    print('move_from_edl')
     if not allowed_ids:
         print(
             'ALLOWED_IDS_CSV_STRING not set, exiting because nothing would be let through')

--- a/rpa/edl_zip_mover.py
+++ b/rpa/edl_zip_mover.py
@@ -1,0 +1,63 @@
+import subprocess
+import os
+import re
+
+
+allowed_ids = [
+    allowed_id.strip() for allowed_id in
+    os.environ['ALLOWED_IDS_CSV_STRING'].split(',')
+]
+
+
+idens = "|".join(allowed_ids)
+allowed_re = re.compile(f'.*({idens}).*')
+
+
+def move_from_edl():
+    if not allowed_ids:
+        print(
+            'ALLOWED_IDS_CSV_STRING not set, exiting because nothing would be let through')
+        exit(1)
+
+    source_bucket = "advana-landing-zone/"
+    destination_bucket = source_bucket
+
+    source_path = f"{source_bucket}edl/sorted/gamechanger_rpa/"
+    destination_path = f"{destination_bucket}bronze/gamechanger/rpa-landing-zone/"
+
+    cmd = f'aws s3 ls --recursive {source_path}'.split()
+    try:
+        file_list = [
+            line.decode().split() for line
+            in subprocess.check_output(cmd).splitlines()
+        ]
+        to_move = []
+        for s3_line in file_list:
+            try:
+                filename = s3_line[3]
+                if allowed_re.match(filename) and not filename.endswith('/'):
+                    to_move.append(filename)
+            except IndexError:
+                # skip empty names, wont have the 3 index
+                continue
+        print('to move', to_move)
+
+        for filename in to_move:
+            try:
+                file_from = f"{source_bucket}{filename}"
+                print('from file', file_from)
+                file_to = f"{destination_path}"
+                print('file to', file_to)
+
+                cmd = f'aws s3 cp s3://{file_from} s3://{file_to}'.split()
+                res = subprocess.check_output(cmd)
+                print('mv response', res)
+            except (subprocess.CalledProcessError, OSError) as e:
+                print(f'Error trying to move {filename}\n\n\n', e)
+
+    except (subprocess.CalledProcessError, OSError) as e:
+        return 'ERROR GETTING RPA FILES'
+
+
+if __name__ == "__main__":
+    move_from_edl()

--- a/rpa/rpa_landing_zone_mover.py
+++ b/rpa/rpa_landing_zone_mover.py
@@ -2,16 +2,11 @@ import boto3
 import tempfile
 from zipfile import ZipFile
 from io import BytesIO
-# from notification import slack
+from notification import slack
 import json
 import typing
 import datetime
 import traceback
-
-
-class slack:
-    def send_notification(msg):
-        print(msg)
 
 
 def notify_with_tb(msg, tb):

--- a/rpa/rpa_landing_zone_mover.py
+++ b/rpa/rpa_landing_zone_mover.py
@@ -1,0 +1,200 @@
+import botocore.client
+import boto3
+import tempfile
+from zipfile import ZipFile
+from io import BytesIO, StringIO
+# from notification import slack
+import json
+
+
+class slack:
+    def send_notification(msg):
+        print(msg)
+
+
+s3 = boto3.resource('s3')
+
+source_bucket = "advana-data-zone"
+source_prefix = "bronze/gamechanger/rpa-landing-zone/"
+
+destination_bucket = "advana-data-zone"
+destination_prefix = "bronze/gamechanger/external-uploads/crawler-downloader"
+
+source_path = f"{source_bucket}/{source_prefix}"
+destination_path = f"{destination_bucket}/{destination_prefix}"
+
+
+def filter_and_move():
+    TODO = """
+        # for each zip in rpa landing zone
+        # get file and unzip, read in any metadata file
+        # set clone name from it
+        # fetch cumulative manifest for that crawler_used if it exists
+            # otherwise create an emtpy one
+        # load previous_hashes into a set
+        # create to_keep dict
+        # for each metadata file
+            # read in and compare hash to previous_hashes
+            # if new, put its hash into to_keep with value of tuple of metadata and pdf file locations
+        
+        # !! have this part changed in crawling instead... rename manifest file to total_manifest
+        # create empty manifest file
+        # load total_manifest file
+            # compare each line hash to to_keep.keys()
+            # if in to_keep, add line to manifest
+
+        # upload all files in to_keep
+        # upload manifest
+
+        # rename old cumulative manifest and upload new cumulative manifest to its location
+
+        # if no errors
+            # delete zip
+        # otherwise try again?
+
+
+
+
+        # update crawler_info if crawler used doesnt exist there
+        # Done by ingest
+        #### Update crawler status postgres table
+        # Crawler download completed - means its sitting in the external-uploads folder
+        # Parse in progress
+        # Complete
+        """
+
+    # initiate s3 client
+    # s3 = boto3.resource('s3')
+
+    # s3 = boto3.resource('s3')
+    # bucket = s3.Bucket('test-bucket')
+    # # Iterates through all the objects, doing the pagination for you. Each obj
+    # # is an ObjectSummary, so it doesn't contain the body. You'll need to call
+    # # get to get the whole body.
+    # for obj in bucket.objects.filter(Prefix=source_path):
+    #     key = obj.key
+    #     body = obj.get()['Body'].read()
+
+    zip_s3_objs = get_filename_s3_obj_map()
+    for filename, s3_obj in zip_s3_objs.items():
+        crawler_used = None
+        try:
+            zip_names = zf.namelist()
+            base_dir = zip_names[0]
+            # create in memory zip file object
+            with create_zip_obj(s3_obj) as zf:
+                # get crawler name from manifest file
+                try:
+                    with zf.open(f'{base_dir}manifest.json') as manifest:
+                        jdoc = json.loads(manifest.readline())
+                        crawler_used = jdoc['crawler_used']
+                        print('\n\n Crawler used was...', crawler_used)
+                except Exception as e:
+                    msg = f"[ERROR] RPA Landing Zone mover failed to handle manifest file: {source_bucket}/{s3_obj.key} > {filename} \n{e}"
+                    slack.send_notification(msg)
+
+                previous_hashes: set = get_previous_manifest_for_crawler(
+                    crawler_used)
+
+                # read metadata files and transfer them and main file to the external-uploads bucket if new
+                not_in_previous_hashes = []
+                errors = []
+
+                for name in zip_names:
+                    if name.endswith('.metadata'):
+                        try:
+                            with zf.open(name) as metadata:
+                                jdoc = json.loads(metadata.readline())
+                                version_hash = jdoc['version_hash']
+                                if not version_hash in previous_hashes:
+                                    not_in_previous_hashes.append(name)
+                        except Exception as e:
+                            errors.append(name)
+
+                a = ['rpa_test/', 'rpa_test/.DS_Store', '__MACOSX/rpa_test/._.DS_Store', 'rpa_test/DHA-PI 1025.01.pdf.metadata', 'rpa_test/DHA-AI 3020-01.pdf', 'rpa_test/DHA-PI 1100.01.pdf', 'rpa_test/DHA-AI 3020-01.pdf.metadata', 'rpa_test/DHA-IP  19-005.pdf', 'rpa_test/DHA-IP  19-004.pdf', 'rpa_test/DHA-IP  19-004.pdf.metadata',
+                     'rpa_test/DHA-IP  19-003.pdf.metadata', 'rpa_test/DHA-PI 1100.01.pdf.metadata', 'rpa_test/DHA-IP  19-003.pdf', 'rpa_test/DHA-IP  19-005.pdf.metadata', 'rpa_test/DHA-PI 3201.05.pdf.metadata', 'rpa_test/DHA-PI 4165.01.pdf.metadata', 'rpa_test/DHA-PI 4165.01.pdf', 'rpa_test/DHA-PI 3201.05.pdf', 'rpa_test/DHA-PI 1025.01.pdf', 'rpa_test/manifest.json']
+
+                for to_move_meta in not_in_previous_hashes:
+                    filename = to_move_meta.replace('.metadata', '')
+                    if filename in zip_names:
+                        upload_new_file(zf, filename)
+                        upload_new_file(zf, to_move_meta)
+
+                upload_new_file(zf, f'{base_dir}crawler_output.json')
+                upload_new_file(zf, f'{base_dir}manifest.json')
+
+                # # namelist retains root structure so files.zip -> files/ , files/thing.txt, files/thing2.txt etc
+                # for name in zf.namelist():
+                #     # get crawler name from manifest file
+                #     if name.endswith('manifest.json'):
+                #         try:
+                #             with open(name) as manifest:
+                #                 jdoc = json.load(manifest.readline())
+                #                 # direct check so it will raise error if it doesnt have that key
+
+                # load_previous_manifest_hashes(crawler_used)
+
+        except Exception as e:
+            msg = f"[ERROR] RPA Landing Zone mover failed to handle zip file: {source_bucket}/{s3_obj.key} \n{e}"
+            slack.send_notification(msg)
+
+    # zf = ZipFile(obj.get()['Body'].read(), 'r')
+
+    # previous_hashes: set = load_previous_manifest_hashes()
+
+    # read through manifest lines
+    # compare hash, if in previous then skip
+    # otherwise move pdf and metadata to external uploads
+
+
+def get_previous_manifest_for_crawler(crawler_used) -> set:
+    previous_hashes = set()
+
+    try:
+        key = f"bronze/gamechanger/data-pipelines/orchestration/crawlers_rpa/{crawler_used}/cumulative-manifest.json"
+        manifest_s3_obj = s3.Object(source_bucket, key)
+        lines = manifest_s3_obj.get()['Body'].read().decode(
+            'utf-8').splitlines()
+        for line in lines:
+            jdoc = json.loads(line)
+            version_hash = jdoc.get('version_hash', None)
+            if version_hash:
+                previous_hashes.add(version_hash)
+
+    except Exception as e:
+        msg = f"[WARN] No cumulative-manifest found for {crawler_used}, a new one will be created"
+        slack.send_notification(msg)
+
+    finally:
+        return previous_hashes
+
+
+def get_filename_s3_obj_map() -> list:
+    out = {}
+    for obj in s3.Bucket(source_bucket).objects.filter(Prefix=source_prefix):
+        if obj.key.endswith('.zip'):
+            _, __, name_with_ext = obj.key.rpartition('/')
+            filename, _, ext = name_with_ext.rpartition('.')
+            out[filename] = obj
+    # I thought I could use filename here, but the archive keeps the original filename so this one is irrelevant when searching in the zip
+    return out
+
+
+def create_zip_obj(s3_obj) -> ZipFile:
+    body_bytes = s3_obj.get()['Body'].read()
+    bytes_obj = BytesIO(body_bytes)
+    zf = ZipFile(bytes_obj, 'r')
+    return zf
+
+
+def upload_new_file(zf_ref, filename):
+    try:
+        with zf_ref.open(filename, "rb") as f:
+            s3.upload_fileobj(
+                f, destination_bucket, destination_path)
+    except Exception as e:
+        pass
+
+
+if __name__ == '__main__':
+    filter_and_move()

--- a/rpa/s3.py
+++ b/rpa/s3.py
@@ -1,0 +1,13 @@
+import subprocess
+
+
+def ls(s3_path: str, recursive: bool = False) -> list:
+    rec = '--recursive' if recursive else ''
+    cmd = f'aws s3 ls {rec} {s3_path}'.split()
+
+    file_list = [
+        line.decode() for line
+        in subprocess.check_output(cmd).splitlines()
+    ]
+
+    return file_list


### PR DESCRIPTION
This script does a ton...
The use case is to move zipped files from the rpa into the uploads folders so they will be ingested
The cac crawler doesn't have reliable storage though, so in order to filter out already downloaded docs this script grabs the cumulative manifest for the spider and filters files and manifest entries based on already seen hashes
It then moves those that are new and a corrected manifest into external uploads, also updates the cumulative manifest