### PR TITLE
task/uot-127438 add is_revoked field to scraped items

### DIFF
--- a/dataPipelines/gc_scrapy/gc_scrapy/items.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/items.py
@@ -25,3 +25,4 @@ class DocItem(scrapy.Item):
     display_source = scrapy.Field()
     data_source = scrapy.Field()
     source_title = scrapy.Field()
+    is_revoked = scrapy.Field()

--- a/dataPipelines/gc_scrapy/gc_scrapy/pipelines.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/pipelines.py
@@ -335,6 +335,10 @@ class AdditionalFieldsPipeline:
         if item.get('doc_num') is None:
             item['doc_num'] = ""
 
+        if item.get('is_revoked') is not None:
+            # ensure is_revoked is part of hash
+            item['version_hash_raw_data']['is_revoked'] = item['is_revoked']
+
         return item
 
 

--- a/dataPipelines/gc_scrapy/gc_scrapy/unfinished/assist_quicksearch_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/unfinished/assist_quicksearch_spider.py
@@ -61,7 +61,10 @@ class AssistQuicksearchSpider(GCSeleniumSpider):
         spec_sheet = response.css('#general_snLabel::text').get()
         doc_general_title = response.css('#general_titleLabel::text').get()
         doc_category = response.css('#doc_categoryLabel::text').get()
+        doc_status = response.css('#general_statusLabel::text').get()
 
+        is_revoked = doc_status != 'Active'
+        
         doc_rows = response.css('#GVRevisionHistory tr:not(:first-child)')
         doc_row: Selector
         for doc_row in doc_rows:
@@ -117,6 +120,7 @@ class AssistQuicksearchSpider(GCSeleniumSpider):
                 source_title=self.source_title,
                 downloadable_items=downloadable_items,
                 version_hash_raw_data=version_hash_fields,
+                is_revoked=is_revoked,
             )
             yield pgi_doc_item
 


### PR DESCRIPTION
This pull request adds an `is_revoked` field to the scraped DocItem which indicates if the document should be ingested as revoked (previously if a document appeared among the scraped documents it was assumed to be _not_ revoked).

Also added the logic to fill in the `is_revoked` field appropriately for the ASSIST crawler.