### PR TITLE
Fixed fasab to inherit GCSpider and not the other thing

### DIFF
--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/fasab_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/fasab_spider.py
@@ -7,7 +7,7 @@ from dataPipelines.gc_scrapy.gc_scrapy.utils import abs_url
 import re
 
 
-class BrickSetSpider(scrapy.Spider):
+class BrickSetSpider(GCSpider):
     name = 'FASAB'
     allowed_domains = ['fasab.gov']
     file_type = "pdf"


### PR DESCRIPTION
FASAB was inheriting the wrong spider class for some reason. Changed so that it inherits the correct one