### PR TITLE
Sec nav bug fixes

### DIFF
--- a/dataPipelines/gc_scrapy/gc_scrapy/GCSpider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/GCSpider.py
@@ -137,7 +137,7 @@ class GCSpider(scrapy.Spider):
             applys text.replace('\u00a0', ' ').encode('ascii', 'ignore').decode('ascii').strip()
         """
 
-        return text.replace('\u00a0', ' ').replace('\u2019', "'").encode('ascii', 'ignore').decode('ascii').strip()
+        return text.replace('\u00a0', ' ').replace('\u2019', "'").replace("&#39;", "'").replace("&nbsp;", " ").encode('ascii', 'ignore').decode('ascii').strip()
 
     @staticmethod
     def ensure_full_href_url(href_raw: str, url_base: str) -> str:

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/secnav_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/secnav_spider.py
@@ -131,6 +131,7 @@ class SecNavSpider(GCSpider):
                     version_hash_raw_data=version_hash_fields,
                     source_page_url=self.source_page_url,
                     office_primary_resp=sponsor,
+                    is_revoked = status != 'Active',
                 )
 
                 self.enqueue(doc)


### PR DESCRIPTION
Fixes to sec_nav crawler:

1. Tracking doc status in is_revoked metadata field so revoked documents can be filtered out from the frontend
2. Cleaning of doc titles (Outreach:&nbsp; America&#39;s Navy -> Outreach: America's Navy)