### PR TITLE
add rotate_user_agent to several non-selenium crawlers

### DIFF
--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/army_pubs_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/army_pubs_spider.py
@@ -20,6 +20,7 @@ class ArmySpider(GCSpider):
 
     base_url = 'https://armypubs.army.mil'
     pub_url = base_url + '/ProductMaps/PubForm/'
+    rotate_user_agent = True
 
     def parse(self, response):
         do_not_process = ["/ProductMaps/PubForm/PB.aspx",

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/army_reserve_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/army_reserve_spider.py
@@ -16,6 +16,7 @@ class ArmyReserveSpider(GCSpider):
 
     file_type = "pdf"
     cac_login_required = False
+    rotate_user_agent = True
 
     section_selector = "div.DnnModule.DnnModule-ICGModulesExpandableTextHtml div.Normal"
 

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/bupers_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/bupers_spider.py
@@ -16,6 +16,7 @@ class BupersSpider(GCSpider):
     doc_type = "BUPERSINST"
     display_org = "US Navy"
     cac_login_required = False
+    rotate_user_agent = True
 
     @staticmethod
     def clean(text):

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/cfr_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/cfr_spider.py
@@ -13,6 +13,7 @@ class CFRSpider(GCSpider):
     display_source = "U.S. Publishing Office"
 
     cac_login_required = False
+    rotate_user_agent = True
     visible_start = "https://www.govinfo.gov/app/collection/cfr"
     start_urls = [
         "https://www.govinfo.gov/wssearch/rb/cfr?fetchChildrenOnly=0"

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/chief_national_guard_bureau_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/chief_national_guard_bureau_spider.py
@@ -16,6 +16,7 @@ class CNGBISpider(GCSpider):
 
     file_type = "pdf"
     doc_type = "CNGBI"
+    rotate_user_agent = True
 
     def parse(self, response):
         rows = response.css('div.WordSection1 table.MsoNormalTable tbody tr')

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/cnss_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/cnss_spider.py
@@ -82,6 +82,7 @@ class CNSSSpider(GCSpider):
         ("https://www.cnss.gov/CNSS/issuances/Supplemental.cfm", supp),
         ("https://www.cnss.gov/CNSS/issuances/historicalIndex.cfm", historical),
     ]
+    rotate_user_agent = True
 
     def parse(self, response):
         # do nothing on start url

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/dcma_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/dcma_spider.py
@@ -13,6 +13,7 @@ class DCMASpider(GCSpider):
     ]
 
     cac_login_required = False
+    rotate_user_agent = True
 
     def parse(self, response):
         sections = response.css('div#accGen div table tbody')

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/dfars_pgi_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/dfars_pgi_spider.py
@@ -14,6 +14,7 @@ class DoDSpider(GCSpider):
     allowed_domains = ['www.acq.osd.mil']
 
     cac_login_required = False
+    rotate_user_agent = True
 
     def parse(self, response: TextResponse):
         options = response.css('select.tocselect option::text')

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/dha_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/dha_spider.py
@@ -17,6 +17,7 @@ class DHASpider(GCSpider):
     file_type = "pdf"
     cac_login_required = False
     randomly_delay_request = True
+    rotate_user_agent = True
 
     @staticmethod
     def get_display(doc_type):

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/executive_orders_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/executive_orders_spider.py
@@ -15,6 +15,8 @@ class ExecutiveOrdersSpider(GCSpider):
     ]
     cac_login_required = False
     doc_type = "EO"
+    rotate_user_agent = True
+    randomly_delay_request = True
 
     @staticmethod
     def make_doc_item_from_dict(doc: dict) -> DocItem:

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/far_subpart_regs_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/far_subpart_regs_spider.py
@@ -20,6 +20,7 @@ class FarSubpartSpider(GCSeleniumSpider):
         'https://www.acquisition.gov/far'
     ]
     cac_login_required = False
+    randomly_delay_request = True
     doc_type = "FAR"
 
     def parse(self, response: TextResponse):

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/fasab_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/fasab_spider.py
@@ -13,6 +13,7 @@ class BrickSetSpider(GCSpider):
     file_type = "pdf"
     start_urls = ['https://fasab.gov/accounting-standards/document-by-chapter/']
     start_url = 'https://fasab.gov/accounting-standards/document-by-chapter/'
+    rotate_user_agent = True
 
     def parse(self, response):
         SET_SELECTOR = 'li'

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/fmr_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/fmr_spider.py
@@ -12,6 +12,7 @@ class FmrSpider(GCSpider):
     download_base_url = 'https://comptroller.defense.gov/'
     doc_type = "DoDFMR"
     cac_login_required = False
+    rotate_user_agent = True
 
     seen = set({})
 

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/hasc_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/hasc_spider.py
@@ -18,6 +18,7 @@ class HASCSpider(GCSpider):
     start_urls = [base_url]
 
     randomly_delay_request = True
+    rotate_user_agent = True
 
     def parse(self, _):
         pages_parser_map = [

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/ic_policies_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/ic_policies_spider.py
@@ -11,6 +11,7 @@ class IcPoliciesSpider(GCSpider):
     start_urls = [
         'https://www.dni.gov/index.php/what-we-do/ic-policies-reports/'
     ]
+    rotate_user_agent = True
 
     def parse(self, response):
         base_url = 'https://www.dni.gov'

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/jcs_pubs_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/jcs_pubs_spider.py
@@ -13,6 +13,7 @@ class JcsPubsSpider(GCSpider):
 
     cac_required_options = [
         'CAC', 'PKI certificate required', 'placeholder', 'FOUO']
+    rotate_user_agent = True
 
     def parse(self, response):
         doc_links = [

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/legislation_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/legislation_spider.py
@@ -10,6 +10,7 @@ bill_version_re = re.compile(r'\((.*)\)')
 class LegislationSpider(GCSpider):
     name = "legislation_pubs"
     cac_login_required = False
+    rotate_user_agent = True
 
     start_urls = [
         "https://www.govinfo.gov/wssearch/rb/bills?fetchChildrenOnly=0"

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/milpersman_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/milpersman_spider.py
@@ -18,6 +18,7 @@ class MilpersmanSpider(GCSpider):
     start_urls = ['https://www.mynavyhr.navy.mil/References/MILPERSMAN/']
     doc_type = "MILPERSMAN"
     cac_login_required = False
+    rotate_user_agent = True
 
     def parse(self, response):
 

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/nato_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/nato_spider.py
@@ -10,6 +10,7 @@ import base64
 
 class NatoSpider(GCSpider):
     name = "nato_stanag"
+    rotate_user_agent = True
 
     source_page_url = "https://nso.nato.int/nso/nsdd/ListPromulg.html"
     start_urls = [

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/navy_personnel_messages_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/navy_personnel_messages_spider.py
@@ -22,6 +22,7 @@ class TRADOCSpider(GCSpider):
     ]
 
     cac_login_required = False
+    rotate_user_agent = True
 
     def parse(self, response: TextResponse):
         links = response.css('div.afMenuLinkHeader > a::attr(href)').getall()

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/omb_pubs_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/omb_pubs_spider.py
@@ -10,6 +10,7 @@ class OmbSpider(GCSpider):
     source_title = "Office of Management and Budget Memoranda"
     display_org = "OMB"
     data_source = "Executive Office of the President"
+    rotate_user_agent = True
 
     start_urls = [
         'https://www.whitehouse.gov/omb/information-for-agencies/memoranda/'

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/sasc_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/sasc_spider.py
@@ -17,6 +17,7 @@ class SASCSpider(GCSpider):
     start_urls = [base_url]
 
     randomly_delay_request = True
+    rotate_user_agent = True
 
     def parse(self, _):
         pages_parser_map = [

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/sorn_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/sorn_spider.py
@@ -10,6 +10,7 @@ class SornSpider(GCSpider):
         "https://www.federalregister.gov/api/v1/agencies/defense-department"
     ]
     cac_login_required = False
+    rotate_user_agent = True
     doc_type = "SORN"
     display_org = "Dept. of Defense"
     display_source = "Federal Registry"

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/stig_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/stig_spider.py
@@ -12,6 +12,7 @@ class StigSpider(GCSpider):
     download_base_url = 'https://public.cyber.mil/'
     doc_type = "STIG"
     cac_login_required = False
+    rotate_user_agent = True
     source_title = "Security Technical Implementation Guides"
     display_org = "Defense Information Systems Agency"
     data_source = "Federal Registry"

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/tradoc_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/tradoc_spider.py
@@ -24,6 +24,7 @@ class TRADOCSpider(GCSpider):
     ]
 
     cac_login_required = False
+    rotate_user_agent = True
 
     _doc_num_rgx = re.compile(r'^(?P<num>[-0-9a-zA-Z]+)?(?: with )?(?:Change (?P<change>\d+))?$',
                               re.IGNORECASE)

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/us_code_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/us_code_spider.py
@@ -21,6 +21,7 @@ class USCodeSpider(GCSpider):
     start_urls = ["https://uscode.house.gov/download/download.shtml"]
     doc_type = "Title"
     cac_login_required = False
+    rotate_user_agent = True
 
     GCSpider.custom_settings["ITEM_PIPELINES"][
         "dataPipelines.gc_scrapy.gc_scrapy.pipelines.USCodeFileDownloadPipeline"


### PR DESCRIPTION
Adding parameter rotate_user_agent to several crawlers to rotate the appropriate crawler's user agent to avoid banning.