### PR TITLE
rought fix for us_code's extension. cannot remove the .pdf

### DIFF
--- a/dataPipelines/gc_scrapy/gc_scrapy/pipelines.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/pipelines.py
@@ -306,9 +306,8 @@ class USCodeFileDownloadPipeline(FileDownloadPipeline):
                             for unzipped_item in self.create_items_from_nested_zip(unzipped_files, item):
                                 self.add_to_manifest(unzipped_item)
 
-                                metadata_download_path = Path(self.output_dir, unzipped_item["doc_name"]).with_suffix(
-                                    ".metadata"
-                                )
+                                metadata_download_path = Path(self.output_dir, unzipped_item["doc_name"])
+                                metadata_download_path = metadata_download_path.with_suffix(metadata_download_path.suffix + ".metadata")
 
                                 with open(metadata_download_path, "w") as f:
                                     try:


### PR DESCRIPTION
Making sure that the metadata files end with .pdf.metadata instead of just .metadata.