### PR TITLE
new spider settings to prevent blacklist yet maintain near identical runtimes

### DIFF
--- a/dataPipelines/gc_scrapy/gc_scrapy/runspider_settings.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/runspider_settings.py
@@ -17,9 +17,9 @@ general_settings = {
     "LOG_LEVEL": "INFO",
     "DOWNLOAD_FAIL_ON_DATALOSS": False,
     
-    # Throttle crawler
-    "DOWNLOAD_DELAY": 0.5,  # Delay between requests in seconds
-    "DOWNLOAD_TIMEOUT": 1,  # seconds
+    # Slow down crawler
+    "DOWNLOAD_DELAY": 0.1,  # Delay between requests in seconds
+    "DOWNLOAD_TIMEOUT": 5,  # seconds
     "RETRY_ENABLE": True,
     "RETRY_TIMES": 2,
     "CONCURRENT_REQUESTS": 10,

--- a/dataPipelines/gc_scrapy/gc_scrapy/runspider_settings.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/runspider_settings.py
@@ -16,8 +16,15 @@ general_settings = {
     "ROBOTSTXT_OBEY": False,
     "LOG_LEVEL": "INFO",
     "DOWNLOAD_FAIL_ON_DATALOSS": False,
+    
+    # Throttle crawler
+    "DOWNLOAD_DELAY": 0.025,  # Delay between requests in seconds
+    "DOWNLOAD_TIMEOUT": 1,  # seconds
+    "RETRY_ENABLE": True,
+    "RETRY_TIMES": 2,
+    "CONCURRENT_REQUESTS": 10,
+    "USER_AGENT": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537"
 }
-
 selenium_settings = {
     "SELENIUM_DRIVER_NAME": "chrome",
     "SELENIUM_DRIVER_EXECUTABLE_PATH": "/usr/local/bin/chromedriver",

--- a/dataPipelines/gc_scrapy/gc_scrapy/runspider_settings.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/runspider_settings.py
@@ -18,12 +18,11 @@ general_settings = {
     "DOWNLOAD_FAIL_ON_DATALOSS": False,
     
     # Throttle crawler
-    "DOWNLOAD_DELAY": 0.025,  # Delay between requests in seconds
+    "DOWNLOAD_DELAY": 0.5,  # Delay between requests in seconds
     "DOWNLOAD_TIMEOUT": 1,  # seconds
     "RETRY_ENABLE": True,
     "RETRY_TIMES": 2,
     "CONCURRENT_REQUESTS": 10,
-    "USER_AGENT": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537"
 }
 selenium_settings = {
     "SELENIUM_DRIVER_NAME": "chrome",

--- a/dataPipelines/gc_scrapy/gc_scrapy/runspider_settings.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/runspider_settings.py
@@ -19,7 +19,7 @@ general_settings = {
     
     # Slow down crawler
     "DOWNLOAD_DELAY": 0.1,  # Delay between requests in seconds
-    "DOWNLOAD_TIMEOUT": 5,  # seconds
+    "DOWNLOAD_TIMEOUT": 3.5,  # seconds
     "RETRY_ENABLE": True,
     "RETRY_TIMES": 2,
     "CONCURRENT_REQUESTS": 10,


### PR DESCRIPTION
findings from new crawler settings

1. monday scheduled crawl
 w/o new settings ran on Oct 2nd, Duration: 6 minutes and 13 seconds
with new settings, Duration: 6 minutes and 10 seconds

2. tuesday
current state ran on Oct 3rd, Duration: 69 minutes and 31 seconds
with new settings, Duration: 70 minutes and 22 seconds and CNSS  did not have previous hashes, where tuesday did, meaning the time would have been shorter.


Additionally added empty oneoff.txt file to prevent the need to recreate each time a new branch is made for oneoff testing