### PR TITLE
New NDAA crawler

### DIFF
--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/ndaa_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/ndaa_spider.py
@@ -23,12 +23,60 @@ class NDAASpider(GCSpider):
             url = link.get("href")
             if url is None:
                 continue
+            if (
+                "news/press-releases/rogers-applauds-committee-passage-fy24-ndaa"
+                in url.lower()
+            ):
+                print(url)
+                yield scrapy.Request(
+                    url=self.base_url + url,
+                    method="GET",
+                    callback=self.parse_press_release,
+                )
             if "calendar/byevent" in url.lower():
                 yield scrapy.Request(
                     url=url, method="GET", callback=self.parse_amendments_considered
                 )
             if url.lower().endswith("pdf"):
                 yield from self.get_doc_from_url(url, page_url)
+
+    def parse_press_release(self, response):
+        page_url = response.url
+        soup = bs4.BeautifulSoup(response.body, features="html.parser")
+
+        title = self.ascii_clean(soup.find(id="page-title").text)
+        date_el = response.css(".pane-node-created .pane-content ::text").get()
+        date_split = date_el.strip().split(" ")
+        print(date_split)
+        month = date_split[0].strip()
+        day = date_split[1].strip().rstrip(",")
+        year = date_split[2].strip()
+
+        date = f"{month} {day} {year}"
+
+        doc_type = self.name
+        doc_name = f"{doc_type} - {date} - {title}"
+
+        html_di = [
+            {"doc_type": "html", "download_url": page_url, "compression_type": None}
+        ]
+
+        fields = {
+            "doc_name": doc_name,
+            "doc_num": " ",  # No doc num for this crawler
+            "doc_title": title,
+            "doc_type": doc_type,
+            "cac_login_required": False,
+            "source_page_url": page_url,
+            "download_url": page_url,
+            "publication_date": date,
+            "display_doc_type": doc_type,
+            "downloadable_items": html_di,
+        }
+        ## Instantiate DocItem class and assign document's metadata values
+        doc_item = self.populate_doc_item(fields)
+
+        yield from doc_item
 
     def parse_amendments_considered(self, response):
         page_url = response.url
@@ -43,6 +91,8 @@ class NDAASpider(GCSpider):
                 yield from self.get_doc_from_url(url, page_url)
 
     def get_doc_from_url(self, url, source_url):
+        url = self.ascii_clean(url)
+        source_url = self.ascii_clean(source_url)
         doc_type = self.name
         doc_num = "0"
         doc_name = url.split("/")[-1].split(".")[-2].replace(" ", "_")

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/ndaa_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/ndaa_spider.py
@@ -178,7 +178,7 @@ class NDAASpider(GCSpider):
                         if am_or_pm.lower() == "pm":
                             hour = str(int(hour) + 12)
                         date = f"{year}:{month}:{day}T{hour}:{minute}:00"
-                
+
                 title = ""
                 if find_title:
                     parent_el = self.ascii_clean(link_el.find_parent().get_text())
@@ -245,9 +245,9 @@ class NDAASpider(GCSpider):
         return self.populate_doc_item(fields)
 
     def populate_doc_item(self, fields: dict) -> Generator[DocItem, Any, None]:
-        display_org = "House Armed Services Committee" # Level 1: GC app 'Source' filter for docs from this crawler
-        data_source = "House Armed Services Committee Publications" # Level 2: GC app 'Source' metadata field for docs from this crawler
-        source_title = "FY24 NDAA Resources" # Level 3 filter
+        display_org = "House Armed Services Committee"  # Level 1: GC app 'Source' filter for docs from this crawler
+        data_source = "House Armed Services Committee Publications"  # Level 2: GC app 'Source' metadata field for docs from this crawler
+        source_title = "NDAA Resources"  # Level 3 filter
 
         doc_name = fields["doc_name"]
         doc_num = fields["doc_num"]

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/ndaa_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/ndaa_spider.py
@@ -23,11 +23,16 @@ class NDAASpider(GCSpider):
             url = link.get("href")
             if url is None:
                 continue
+            if "fy24-ndaa-floor-amendment-tracker" in url.lower():
+                yield scrapy.Request(
+                    url=self.base_url + url,
+                    method="GET",
+                    callback=self.parse_amendment_tracker,
+                )
             if (
                 "news/press-releases/rogers-applauds-committee-passage-fy24-ndaa"
                 in url.lower()
             ):
-                print(url)
                 yield scrapy.Request(
                     url=self.base_url + url,
                     method="GET",
@@ -39,6 +44,43 @@ class NDAASpider(GCSpider):
                 )
             if url.lower().endswith("pdf"):
                 yield from self.get_doc_from_url(url, page_url)
+
+    def parse_amendment_tracker(self, response):
+        page_url = response.url
+        soup = bs4.BeautifulSoup(response.body, features="html.parser")
+
+        title = self.ascii_clean(soup.find(id="page-title").text)
+        date_el = response.xpath("//p[(((count(preceding-sibling::*) + 1) = 2) and parent::*)]").get()
+        date_split = date_el.strip().split(" ")
+        month = date_split[2].strip()
+        day = date_split[3].strip().rstrip(",")
+        year = date_split[4].strip()
+
+        date = f"{month} {day} {year}"
+
+        doc_type = self.name
+        doc_name = f"{doc_type} - {date} - {title}"
+
+        html_di = [
+            {"doc_type": "html", "download_url": page_url, "compression_type": None}
+        ]
+
+        fields = {
+            "doc_name": doc_name,
+            "doc_num": " ",  # No doc num for this crawler
+            "doc_title": title,
+            "doc_type": doc_type,
+            "cac_login_required": False,
+            "source_page_url": page_url,
+            "download_url": page_url,
+            "publication_date": date,
+            "display_doc_type": doc_type,
+            "downloadable_items": html_di,
+        }
+        ## Instantiate DocItem class and assign document's metadata values
+        doc_item = self.populate_doc_item(fields)
+
+        yield from doc_item     
 
     def parse_press_release(self, response):
         page_url = response.url

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/ndaa_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/ndaa_spider.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+import bs4
+from dataPipelines.gc_scrapy.gc_scrapy.items import DocItem
+from dataPipelines.gc_scrapy.gc_scrapy.GCSpider import GCSpider
+from dataPipelines.gc_scrapy.gc_scrapy.utils import dict_to_sha256_hex_digest
+from urllib.parse import urlparse
+import scrapy
+
+
+class NDAASpider(GCSpider):
+    name = "ndaa_fy24"  # Crawler name
+    rotate_user_agent = True
+    base_url = "https://armedservices.house.gov"
+    start_urls = [base_url + "/fy24-ndaa-resources"]
+
+    def parse(self, response):
+        page_url = response.url
+
+        soup = bs4.BeautifulSoup(response.body, features="html.parser")
+        for link in soup.find_all("a"):
+            if link is None:
+                continue
+            url = link.get("href")
+            if url is None:
+                continue
+            if "calendar/byevent" in url.lower():
+                yield scrapy.Request(
+                    url=url, method="GET", callback=self.parse_amendments_considered
+                )
+            if url.lower().endswith("pdf"):
+                yield from self.get_doc_from_url(url, page_url)
+
+    def parse_amendments_considered(self, response):
+        page_url = response.url
+        soup = bs4.BeautifulSoup(response.body, features="html.parser")
+        for link in soup.find_all("a"):
+            if link is None:
+                continue
+            url = link.get("href")
+            if url is None:
+                continue
+            if url.lower().endswith("pdf"):
+                yield from self.get_doc_from_url(url, page_url)
+
+    def get_doc_from_url(self, url, source_url):
+        doc_type = self.name
+        doc_num = "0"
+        doc_name = url.split("/")[-1].split(".")[-2].replace(" ", "_")
+        doc_title = self.name + doc_name
+        chapter_date = ""
+        publication_date = ""
+        exp_date = ""
+        issuance_num = ""
+
+        if url.lower().startswith("http"):
+            pdf_url = url
+        else:
+            pdf_url = self.base_url + url.strip()
+        pdf_di = [
+            {"doc_type": "pdf", "download_url": pdf_url, "compression_type": None}
+        ]
+
+        fields = {
+            "doc_name": doc_name.strip(),
+            "doc_title": doc_title,
+            "doc_num": doc_num,
+            "doc_type": doc_type.strip(),
+            "display_doc_type": doc_type.strip(),
+            "publication_date": publication_date,
+            "cac_login_required": False,
+            "source_page_url": source_url.strip(),
+            "downloadable_items": pdf_di,
+            "download_url": pdf_url,
+        }
+        return self.populate_doc_item(fields)
+
+    def populate_doc_item(self, fields):
+        display_org = (
+            "ndaa_fy24"  # Level 1: GC app 'Source' filter for docs from this crawler
+        )
+        data_source = "House Armed Services Committee"  # Level 2: GC app 'Source' metadata field for docs from this crawler
+        source_title = "House Armed Services Committee"  # Level 3 filter
+
+        doc_name = fields["doc_name"]
+        doc_num = fields["doc_num"]
+        doc_title = fields["doc_title"]
+        doc_type = fields["doc_type"]
+        publication_date = fields["publication_date"]
+        cac_login_required = fields["cac_login_required"]
+        download_url = fields["download_url"]
+        display_doc_type = fields["display_doc_type"]
+        downloadable_items = fields["downloadable_items"]
+
+        display_source = data_source + " - " + source_title
+        display_title = doc_type + " " + doc_num + ": " + doc_title
+        is_revoked = False
+        source_page_url = self.start_urls[0]
+        source_fqdn = urlparse(source_page_url).netloc
+        version_hash_fields = {
+            "doc_name": doc_name,
+            "doc_num": doc_num,
+            "publication_date": publication_date,
+            "download_url": download_url,
+            "display_title": display_title,
+        }
+        version_hash = dict_to_sha256_hex_digest(version_hash_fields)
+
+        yield DocItem(
+            doc_name=doc_name,
+            doc_title=doc_title,
+            doc_num=doc_num,
+            doc_type=doc_type,
+            display_doc_type=display_doc_type,
+            publication_date=publication_date,
+            cac_login_required=cac_login_required,
+            crawler_used=self.name,
+            downloadable_items=downloadable_items,
+            source_page_url=source_page_url,
+            source_fqdn=source_fqdn,
+            download_url=download_url,
+            version_hash_raw_data=version_hash_fields,
+            version_hash=version_hash,
+            display_org=display_org,
+            data_source=data_source,
+            source_title=source_title,
+            display_source=display_source,
+            display_title=display_title,
+            file_ext=doc_type,
+            is_revoked=is_revoked,
+        )

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/ndaa_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/ndaa_spider.py
@@ -156,7 +156,13 @@ class NDAASpider(GCSpider):
             if date == "":  # need format 2023-06-14T00:00:00
                 next_sibling = link_el.find_next_sibling("strong")
                 if next_sibling is not None:
-                    print(next_sibling.get_text())
+                    date_elements = next_sibling.get_text().strip().split(" ")
+                    month, day, year = date_elements[8].split("/")
+                    hour, minute = date_elements[10].split(":")
+                    am_or_pm = date_elements[11]
+                    if am_or_pm.lower() == "pm":
+                        hour = str(int(hour) + 12)
+                    date = f"{year}:{month}:{day}T{hour}:{minute}:00"
             url = link_el.get("href")
             if url is None:
                 continue

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/ndaa_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/ndaa_spider.py
@@ -83,7 +83,7 @@ class NDAASpider(GCSpider):
         fields = {
             "doc_name": doc_name,
             "doc_num": " ",  # No doc num for this crawler
-            "doc_title": title,
+            "doc_title": title.replace("_", " "),
             "doc_type": doc_type,
             "cac_login_required": False,
             "source_page_url": page_url,
@@ -118,7 +118,7 @@ class NDAASpider(GCSpider):
         fields = {
             "doc_name": doc_name,
             "doc_num": " ",  # No doc num for this crawler
-            "doc_title": title,
+            "doc_title": title.replace("_", " "),
             "doc_type": doc_type,
             "cac_login_required": False,
             "source_page_url": page_url,
@@ -231,7 +231,7 @@ class NDAASpider(GCSpider):
 
         fields = {
             "doc_name": doc_name.strip(),
-            "doc_title": doc_title,
+            "doc_title": doc_title.replace("_", " "),
             "doc_num": doc_num,
             "doc_type": doc_type.strip(),
             "display_doc_type": doc_type.strip(),

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/ndaa_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/ndaa_spider.py
@@ -15,7 +15,8 @@ import scrapy
 
 
 class NDAASpider(GCSpider):
-    name = "NDAA FY24"  # Crawler name
+    name = "ndaa"  # Crawler name
+    display_name = "NDAA FY24"
     rotate_user_agent = True
     base_url = "https://armedservices.house.gov"
     start_urls = [base_url + "/fy24-ndaa-resources"]
@@ -72,7 +73,7 @@ class NDAASpider(GCSpider):
         date_el = response.css("p:nth-child(2) ::text").get()
         date = self.parse_date(date_el)
 
-        doc_type = self.name
+        doc_type = self.display_name
         doc_name = f"{doc_type} - {date} - {title}"
 
         html_di = [
@@ -107,7 +108,7 @@ class NDAASpider(GCSpider):
         date_el = response.css(".pane-node-created .pane-content ::text").get()
         date = self.parse_date(date_el)
 
-        doc_type = self.name
+        doc_type = self.display_name
         doc_name = f"{doc_type} - {date} - {title}"
 
         html_di = [
@@ -201,12 +202,12 @@ class NDAASpider(GCSpider):
     ) -> Generator[DocItem, Any, None]:
         url = self.ascii_clean(url)
         source_url = self.ascii_clean(source_url)
-        doc_type = self.name
+        doc_type = self.display_name
         doc_num = "0"
         doc_name = (
             url.split("/")[-1].split(".")[-2].replace(" ", "_").replace("%20", "_")
         )
-        doc_title = self.name + doc_name
+        doc_title = doc_type + " " + doc_name
 
         if url.lower().startswith("http"):
             pdf_url = url

--- a/paasJobs/crawler_schedule/saturday.txt
+++ b/paasJobs/crawler_schedule/saturday.txt
@@ -2,3 +2,4 @@ dod_issuances_spider.py
 fmr_spider.py
 far_subpart_regs_spider.py
 maradmin_spider.py
+ndaa_spider.py


### PR DESCRIPTION
### New NDAA crawler
Scrapes all the resources for the FY 24 NDAA published by the House Armed Services Committee at https://armedservices.house.gov/fy24-ndaa-resources. There are three main types of documents associated:

1. Amendments considered https://docs.house.gov/Committee/Calendar/ByEvent.aspx?EventID=115846
2. Sub-committee/chairmain marks
3. HTML docs for press releases or schedules

I also used this PR to introduce type hinting for a spider

This new NDAA crawler has been added to the Saturday schedule

## Testing steps

- [ ] git checkout new-crawler-ndaa
- [ ] run `export PYTHONPATH="$(pwd)"`
- [ ] run `CRAWLER_DATA_ROOT=./tmp`
- [ ] run `mkdir -p "$CRAWLER_DATA_ROOT"`
- [ ] run `touch "$CRAWLER_DATA_ROOT/prev-manifest.json"`
- [ ] run `scrapy runspider dataPipelines/gc_scrapy/gc_scrapy/spiders/ndaa_spider.py   -a download_output_dir="$CRAWLER_DATA_ROOT"   -a previous_manifest_location="$CRAWLER_DATA_ROOT/prev-manifest.json"   -o "$CRAWLER_DATA_ROOT/output.json"`
- [ ] After execution stops confirm that all documents that need to be scraped are present in ./tmp
- [ ] Confirm that each type of document has all of the proper metadata