### PR TITLE
NDAA_pubs character fix

### DIFF
--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/ndaa_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/ndaa_spider.py
@@ -213,8 +213,7 @@ class NDAASpider(GCSpider):
         doc_num = "0"
         doc_type = "Policy"
         doc_name = (
-            url.split("/")[-1].split(".")[-2].replace(" ", "_").replace("%20", "_").replace("%28", "_").replace("%29", "_")
-        )
+            url.split("/")[-1].split(".")[-2].replace(" ", "_").replace("%20", "_").replace("%28", "_").replace("%29", "_")        )
         if doc_title == "":
             doc_title = doc_name
 

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/ndaa_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/ndaa_spider.py
@@ -213,7 +213,7 @@ class NDAASpider(GCSpider):
         doc_num = "0"
         doc_type = "Policy"
         doc_name = (
-            url.split("/")[-1].split(".")[-2].replace(" ", "_").replace("%20", "_")
+            url.split("/")[-1].split(".")[-2].replace(" ", "_").replace("%20", "_").replace("%28", "_").replace("%29", "_")
         )
         if doc_title == "":
             doc_title = doc_name


### PR DESCRIPTION
There was a disconnect between the number of files extracted by this crawler and the number that were ingested into dev and prod. This crawler was getting 95 docs and only 92 were ingested. We found three problematic documents, 2 were unnecessary html files and the third was a document named: FY24_NDAA_Strategic_Forces_Subcommittee_Mark_UPDATED_%28004%29.pdf. This was apparently causing an issue because of the characters in the document name.

This PR handles the edge case and converts the %28 and %29 values to underscores. 

After running this on dev I have confirmed that 93 documents are ingested and the new file is present. 