### PR TITLE
New crawler disa pubs

### DIFF
--- a/.github/workflows/pull_request_template.md
+++ b/.github/workflows/pull_request_template.md
@@ -1,0 +1,14 @@
+## Description
+
+
+## Result of Crawler Run on Dev
+```yaml 
+
+```
+
+## Example Metadata
+```javascript 
+{
+
+}
+```

--- a/.github/workflows/verify-spiders-scheduled.yml
+++ b/.github/workflows/verify-spiders-scheduled.yml
@@ -8,7 +8,7 @@ on:
   push:
     branches: [ dev ]
   pull_request:
-    branches: [ dev ]
+    branches: [ dev, main ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,12 @@
-FROM --platform=linux/amd64 ubuntu:latest
+FROM --platform=linux/amd64 ubuntu:20.04
+
+# Set timezone for tzdata
+ENV TZ=UTC
+
+# Install tzdata non-interactively
+RUN ln -fs /usr/share/zoneinfo/$TZ /etc/localtime && \
+    apt-get update && \
+    apt-get install -y tzdata
 
 # Update and install necessary packages
 RUN apt-get update && apt-get upgrade -y ca-certificates && \

--- a/dataPipelines/gc_scrapy/gc_scrapy/doc_item_fields.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/doc_item_fields.py
@@ -1,11 +1,13 @@
-from dataPipelines.gc_scrapy.gc_scrapy.utils import dict_to_sha256_hex_digest
 from urllib.parse import urlparse
 from datetime import datetime
 
+from dataPipelines.gc_scrapy.gc_scrapy.utils import dict_to_sha256_hex_digest
 from dataPipelines.gc_scrapy.gc_scrapy.items import DocItem
 
 
 class DocItemFields:
+    """Designed to store all fields necessary to generate DocItems"""
+
     def __init__(
         self,
         doc_name: str,
@@ -31,7 +33,8 @@ class DocItemFields:
         self.download_url = download_url
         self.file_ext = file_ext
 
-    def _get_version_hash_fields(self):
+    def get_version_hash_fields(self) -> dict:
+        """Returns a dict of the fields used for hashing"""
         return {
             "doc_name": self.doc_name,
             "doc_num": self.doc_num,
@@ -43,11 +46,22 @@ class DocItemFields:
     def populate_doc_item(
         self, display_org: str, data_source: str, source_title: str, crawler_used: str
     ) -> DocItem:
+        """Takes the data stored in the current object and populates then returns a scrapy DocItem
+
+        Args:
+            display_org (str): Level 1 - GC app 'Source' filter for docs from this crawler
+            data_source (str): Level 2 - GC app 'Source' metadata field for docs from this crawler
+            source_title (str): Level 3 - filter
+            crawler_used (str): name of crawler used
+
+        Returns:
+            DocItem: scrapy.Item sublcass for storing Documents in GC
+        """
 
         display_source = data_source + " - " + source_title
         is_revoked = False
         source_fqdn = urlparse(self.source_page_url).netloc
-        version_hash_fields = self._get_version_hash_fields()
+        version_hash_fields = self.get_version_hash_fields()
         version_hash = dict_to_sha256_hex_digest(version_hash_fields)
 
         return DocItem(

--- a/dataPipelines/gc_scrapy/gc_scrapy/doc_item_fields.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/doc_item_fields.py
@@ -1,0 +1,75 @@
+from dataPipelines.gc_scrapy.gc_scrapy.utils import dict_to_sha256_hex_digest
+from urllib.parse import urlparse
+from datetime import datetime
+
+from dataPipelines.gc_scrapy.gc_scrapy.items import DocItem
+
+
+class DocItemFields:
+    def __init__(
+        self,
+        doc_name: str,
+        doc_title: str,
+        doc_num: str,
+        doc_type: str,
+        publication_date: datetime,
+        cac_login_required: bool,
+        source_page_url: str,
+        downloadable_items: dict,
+        download_url: str,
+        file_ext: str,
+    ):
+        self.doc_name = doc_name
+        self.doc_title = doc_title
+        self.doc_num = doc_num
+        self.doc_type = doc_type
+        self.display_doc_type = doc_type
+        self.publication_date = publication_date.strftime("%Y-%m-%dT%H:%M:%S")
+        self.cac_login_required = cac_login_required
+        self.source_page_url = source_page_url
+        self.downloadable_items = downloadable_items
+        self.download_url = download_url
+        self.file_ext = file_ext
+
+    def _get_version_hash_fields(self):
+        return {
+            "doc_name": self.doc_name,
+            "doc_num": self.doc_num,
+            "publication_date": self.publication_date,
+            "download_url": self.download_url,
+            "display_title": self.doc_title,
+        }
+
+    def populate_doc_item(
+        self, display_org: str, data_source: str, source_title: str, crawler_used: str
+    ) -> DocItem:
+
+        display_source = data_source + " - " + source_title
+        is_revoked = False
+        source_fqdn = urlparse(self.source_page_url).netloc
+        version_hash_fields = self._get_version_hash_fields()
+        version_hash = dict_to_sha256_hex_digest(version_hash_fields)
+
+        return DocItem(
+            doc_name=self.doc_name,
+            doc_title=self.doc_title,
+            doc_num=self.doc_num,
+            doc_type=self.doc_type,
+            display_doc_type=self.display_doc_type,
+            publication_date=self.publication_date,
+            cac_login_required=self.cac_login_required,
+            crawler_used=crawler_used,
+            downloadable_items=self.downloadable_items,
+            source_page_url=self.source_page_url,
+            source_fqdn=source_fqdn,
+            download_url=self.download_url,
+            version_hash_raw_data=version_hash_fields,
+            version_hash=version_hash,
+            display_org=display_org,
+            data_source=data_source,
+            source_title=source_title,
+            display_source=display_source,
+            display_title=self.doc_title,
+            file_ext=self.file_ext,
+            is_revoked=is_revoked,
+        )

--- a/dataPipelines/gc_scrapy/gc_scrapy/doc_item_fields.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/doc_item_fields.py
@@ -32,6 +32,7 @@ class DocItemFields:
         self.downloadable_items = downloadable_items
         self.download_url = download_url
         self.file_ext = file_ext
+        self.display_title = doc_type + " " + doc_num + ": " + doc_title
 
     def get_version_hash_fields(self) -> dict:
         """Returns a dict of the fields used for hashing"""
@@ -42,6 +43,10 @@ class DocItemFields:
             "download_url": self.download_url,
             "display_title": self.doc_title,
         }
+
+    def set_display_name(self, name: str) -> None:
+        """Update display name for DocItemFields instance"""
+        self.display_title = name
 
     def populate_doc_item(
         self, display_org: str, data_source: str, source_title: str, crawler_used: str
@@ -83,7 +88,7 @@ class DocItemFields:
             data_source=data_source,
             source_title=source_title,
             display_source=display_source,
-            display_title=self.doc_title,
+            display_title=self.display_title,
             file_ext=self.file_ext,
             is_revoked=is_revoked,
         )

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/disa_pubs_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/disa_pubs_spider.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Generator
+import bs4
+import re
+from dataPipelines.gc_scrapy.gc_scrapy.items import DocItem
+from dataPipelines.gc_scrapy.gc_scrapy.GCSpider import GCSpider
+from dataPipelines.gc_scrapy.gc_scrapy.utils import (
+    dict_to_sha256_hex_digest,
+    get_pub_date,
+)
+from urllib.parse import urljoin
+from datetime import datetime
+
+from urllib.parse import urlparse
+import scrapy
+
+
+class DisaPubsSpider(GCSpider):
+    name = "DISA_pubs"  # Crawler name
+    rotate_user_agent = True
+    date_format = "%m/%d/%y"
+
+    domain = "disa.mil"
+    base_url = f"https://{domain}"
+    allowed_domains = [domain]
+    start_urls = [
+        f"{base_url}/About/DISA-Issuances/Instructions",
+        f"{base_url}/About/DISA-Issuances/Circulars",
+    ]
+
+    def parse(self, response: scrapy.http.Response) -> Generator[DocItem, Any, None]:
+        page_url = response.url
+        soup = bs4.BeautifulSoup(response.body, features="html.parser")
+        main_content = soup.find(id="main-content")
+        for row in main_content.find_all("tr"):
+            row_items = row.find_all("td")
+
+            if len(row_items) == 3:  # Ensure elements are present and skip header row
+                url = self.base_url + row_items[0].find("a").get("href")
+
+                doc_name = self.ascii_clean(row_items[0].find("a").get_text().strip())
+                doc_num = doc_name.split(" ")[-1]
+                doc_type = self.get_doc_type(doc_name)
+                doc_title = self.ascii_clean(row_items[1].get_text().strip())
+
+                # one date has an accidental space
+                published = row_items[2].get_text().strip().replace(" ", "")
+                published_timestamp = datetime.strptime(published, self.date_format)
+                published_date = published_timestamp.strftime("%Y-%m-%dT%H:%M:%S")
+
+                pdf_di = [
+                    {"doc_type": "pdf", "download_url": url, "compression_type": None}
+                ]
+
+                fields = {
+                    "doc_name": doc_name,
+                    "doc_title": doc_title,
+                    "doc_num": doc_num,
+                    "doc_type": doc_type,
+                    "display_doc_type": doc_type,
+                    "publication_date": published_date,
+                    "cac_login_required": False,
+                    "source_page_url": page_url,
+                    "downloadable_items": pdf_di,
+                    "download_url": url,
+                    "file_ext": "pdf",
+                }
+
+                yield self.populate_doc_item(fields)
+
+    def get_doc_type(self, doc_name: str) -> str:
+        if "DISAC" in doc_name:
+            return "Circular"
+        elif "DISAI" in doc_name:
+            return "Instruction"
+        else:
+            raise ValueError(f"Unexpected value for doc_name {doc_name}")
+
+    def populate_doc_item(self, fields: dict) -> DocItem:
+        display_org = "Defense Information Systems Agency"  # Level 1: GC app 'Source' filter for docs from this crawler
+        data_source = "Defense Information Systems Agency"  # Level 2: GC app 'Source' metadata field for docs from this crawler
+        source_title = "DISA Policy/Issuances"  # Level 3 filter
+
+        doc_name = fields["doc_name"]
+        doc_num = fields["doc_num"]
+        doc_title = fields["doc_title"]
+        doc_type = fields["doc_type"]
+        publication_date = fields["publication_date"]
+        cac_login_required = fields["cac_login_required"]
+        download_url = fields["download_url"]
+        display_doc_type = fields["display_doc_type"]
+        downloadable_items = fields["downloadable_items"]
+        file_ext = fields["file_ext"]
+        source_page_url = fields["source_page_url"]
+
+        display_source = data_source + " - " + source_title
+        is_revoked = False
+        source_fqdn = urlparse(source_page_url).netloc
+        version_hash_fields = {
+            "doc_name": doc_name,
+            "doc_num": doc_num,
+            "publication_date": publication_date,
+            "download_url": download_url,
+            "display_title": doc_title,
+        }
+        version_hash = dict_to_sha256_hex_digest(version_hash_fields)
+
+        return DocItem(
+            doc_name=doc_name,
+            doc_title=doc_title,
+            doc_num=doc_num,
+            doc_type=doc_type,
+            display_doc_type=display_doc_type,
+            publication_date=publication_date,
+            cac_login_required=cac_login_required,
+            crawler_used=self.name,
+            downloadable_items=downloadable_items,
+            source_page_url=source_page_url,
+            source_fqdn=source_fqdn,
+            download_url=download_url,
+            version_hash_raw_data=version_hash_fields,
+            version_hash=version_hash,
+            display_org=display_org,
+            data_source=data_source,
+            source_title=source_title,
+            display_source=display_source,
+            display_title=doc_title,
+            file_ext=file_ext,
+            is_revoked=is_revoked,
+        )

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/disa_pubs_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/disa_pubs_spider.py
@@ -1,18 +1,13 @@
 # -*- coding: utf-8 -*-
 from typing import Any, Generator
 import bs4
-import re
-from dataPipelines.gc_scrapy.gc_scrapy.items import DocItem
-from dataPipelines.gc_scrapy.gc_scrapy.GCSpider import GCSpider
-from dataPipelines.gc_scrapy.gc_scrapy.utils import (
-    dict_to_sha256_hex_digest,
-    get_pub_date,
-)
+import scrapy
 from urllib.parse import urljoin
 from datetime import datetime
 
-from urllib.parse import urlparse
-import scrapy
+from dataPipelines.gc_scrapy.gc_scrapy.doc_item_fields import DocItemFields
+from dataPipelines.gc_scrapy.gc_scrapy.items import DocItem
+from dataPipelines.gc_scrapy.gc_scrapy.GCSpider import GCSpider
 
 
 class DisaPubsSpider(GCSpider):
@@ -23,16 +18,20 @@ class DisaPubsSpider(GCSpider):
     """
 
     name = "DISA_pubs"  # Crawler name
-    rotate_user_agent = True
-    date_format = "%m/%d/%y"
+    display_org = "Defense Information Systems Agency"  # Level 1: GC app 'Source' filter for docs from this crawler
+    data_source = "Defense Information Systems Agency"  # Level 2: GC app 'Source' metadata field for docs from this crawler
+    source_title = "DISA Policy/Issuances"  # Level 3 filter
 
     domain = "disa.mil"
     base_url = f"https://{domain}"
     allowed_domains = [domain]
     start_urls = [
-        f"{base_url}/About/DISA-Issuances/Instructions",
-        f"{base_url}/About/DISA-Issuances/Circulars",
+        urljoin(base_url, "/About/DISA-Issuances/Instructions"),
+        urljoin(base_url, "/About/DISA-Issuances/Circulars"),
     ]
+
+    rotate_user_agent = True
+    date_format = "%m/%d/%y"
 
     def parse(self, response: scrapy.http.Response) -> Generator[DocItem, Any, None]:
         page_url = response.url
@@ -60,28 +59,31 @@ class DisaPubsSpider(GCSpider):
                 {"doc_type": "pdf", "download_url": url, "compression_type": None}
             ]
 
-            fields = {
-                "doc_name": doc_name,
-                "doc_title": doc_title,
-                "doc_num": doc_num,
-                "doc_type": doc_type,
-                "display_doc_type": doc_type,
-                "publication_date": published_date,
-                "cac_login_required": False,
-                "source_page_url": page_url,
-                "downloadable_items": pdf_di,
-                "download_url": url,
-                "file_ext": "pdf",
-            }
+            fields = DocItemFields(
+                doc_name=doc_name,
+                doc_title=doc_title,
+                doc_num=doc_num,
+                doc_type=doc_type,
+                publication_date=published_date,
+                cac_login_required=False,
+                source_page_url=page_url,
+                downloadable_items=pdf_di,
+                download_url=url,
+                file_ext="pdf",
+            )
 
-            yield self.populate_doc_item(fields)
+            yield fields.populate_doc_item(
+                display_org=self.display_org,
+                data_source=self.data_source,
+                source_title=self.source_title,
+                crawler_used=self.name,
+            )
 
-    def format_publication_date(self, input_date: str) -> str:
+    def format_publication_date(self, input_date: str) -> datetime:
         # dates formatted as 03/17/17 and one has an accidental space (04/15/ 13)
         published = input_date.strip().replace(" ", "")
         published_timestamp = datetime.strptime(published, self.date_format)
-        published_date = published_timestamp.strftime("%Y-%m-%dT%H:%M:%S")
-        return published_date
+        return published_timestamp
 
     def get_doc_type(self, doc_name: str) -> str:
         if "DISAC" in doc_name:
@@ -90,56 +92,3 @@ class DisaPubsSpider(GCSpider):
             return "Instruction"
         else:
             raise ValueError(f"Unexpected value for doc_name {doc_name}")
-
-    def populate_doc_item(self, fields: dict) -> DocItem:
-        display_org = "Defense Information Systems Agency"  # Level 1: GC app 'Source' filter for docs from this crawler
-        data_source = "Defense Information Systems Agency"  # Level 2: GC app 'Source' metadata field for docs from this crawler
-        source_title = "DISA Policy/Issuances"  # Level 3 filter
-
-        doc_name = fields["doc_name"]
-        doc_num = fields["doc_num"]
-        doc_title = fields["doc_title"]
-        doc_type = fields["doc_type"]
-        publication_date = fields["publication_date"]
-        cac_login_required = fields["cac_login_required"]
-        download_url = fields["download_url"]
-        display_doc_type = fields["display_doc_type"]
-        downloadable_items = fields["downloadable_items"]
-        file_ext = fields["file_ext"]
-        source_page_url = fields["source_page_url"]
-
-        display_source = data_source + " - " + source_title
-        is_revoked = False
-        source_fqdn = urlparse(source_page_url).netloc
-        version_hash_fields = {
-            "doc_name": doc_name,
-            "doc_num": doc_num,
-            "publication_date": publication_date,
-            "download_url": download_url,
-            "display_title": doc_title,
-        }
-        version_hash = dict_to_sha256_hex_digest(version_hash_fields)
-
-        return DocItem(
-            doc_name=doc_name,
-            doc_title=doc_title,
-            doc_num=doc_num,
-            doc_type=doc_type,
-            display_doc_type=display_doc_type,
-            publication_date=publication_date,
-            cac_login_required=cac_login_required,
-            crawler_used=self.name,
-            downloadable_items=downloadable_items,
-            source_page_url=source_page_url,
-            source_fqdn=source_fqdn,
-            download_url=download_url,
-            version_hash_raw_data=version_hash_fields,
-            version_hash=version_hash,
-            display_org=display_org,
-            data_source=data_source,
-            source_title=source_title,
-            display_source=display_source,
-            display_title=doc_title,
-            file_ext=file_ext,
-            is_revoked=is_revoked,
-        )

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/disa_pubs_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/disa_pubs_spider.py
@@ -69,6 +69,7 @@ class DisaPubsSpider(GCSpider):
                 download_url=url,
                 file_ext="pdf",
             )
+            fields.set_display_name(f"{fields.doc_name}: {fields.doc_title}")
 
             yield fields.populate_doc_item(
                 display_org=self.display_org,

--- a/paasJobs/crawler_schedule/tuesday.txt
+++ b/paasJobs/crawler_schedule/tuesday.txt
@@ -3,3 +3,4 @@ cfr_spider.py
 dha_spider
 cnss_spider
 us_code_spider
+disa_pubs_spider.py

--- a/runCrawler.sh
+++ b/runCrawler.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 
+print_help () {
+    echo "Usage: ./runCrawler.sh -c={crawler name} --reset {optional: resets the data directory before running}"
+    echo "Example: ./runCrawler.sh -c=disa_pubs_spider --reset"
+    exit 1
+}
+
 RESET=false
+CRAWLER=""
 for i in "$@"; do
     case $i in
         -c=*|--crawler=*)
@@ -12,14 +19,17 @@ for i in "$@"; do
             shift # past argument with no value
         ;;
         -*|--*)
-            echo "Unknown option $i"
-            exit 1
+            print_help
         ;;
         *)
         ;;
     esac
 done
 
+if [$CRAWLER == ""]; then
+    echo "ERROR: Please use the -c option to specify a crawler"
+    print_help
+fi
 
 export PYTHONPATH="$(pwd)"
 CRAWLER_DATA_ROOT=./tmp/$CRAWLER

--- a/runCrawler.sh
+++ b/runCrawler.sh
@@ -1,10 +1,40 @@
 #!/bin/bash
 
+RESET=false
+for i in "$@"; do
+    case $i in
+        -c=*|--crawler=*)
+            CRAWLER="${i#*=}"
+            shift # past argument=value
+        ;;
+        --reset)
+            RESET=true
+            shift # past argument with no value
+        ;;
+        -*|--*)
+            echo "Unknown option $i"
+            exit 1
+        ;;
+        *)
+        ;;
+    esac
+done
+
+
 export PYTHONPATH="$(pwd)"
-CRAWLER_DATA_ROOT=./tmp
+CRAWLER_DATA_ROOT=./tmp/$CRAWLER
 mkdir -p "$CRAWLER_DATA_ROOT"
+
+echo "CRAWLER   = ${CRAWLER}"
+echo "RESET     = ${RESET}"
+echo "DATA_ROOT = ${CRAWLER_DATA_ROOT}"
+
+if $RESET; then
+    rm $CRAWLER_DATA_ROOT/*
+fi
+
 touch "$CRAWLER_DATA_ROOT/prev-manifest.json"
-scrapy runspider dataPipelines/gc_scrapy/gc_scrapy/spiders/hasc_spider.py \
--a download_output_dir="$CRAWLER_DATA_ROOT" \
--a previous_manifest_location="$CRAWLER_DATA_ROOT/prev-manifest.json" \
--o "$CRAWLER_DATA_ROOT/output.json"
+scrapy runspider dataPipelines/gc_scrapy/gc_scrapy/spiders/$CRAWLER.py \
+    -a download_output_dir="$CRAWLER_DATA_ROOT" \
+    -a previous_manifest_location="$CRAWLER_DATA_ROOT/prev-manifest.json" \
+    -o "$CRAWLER_DATA_ROOT/output.json"


### PR DESCRIPTION
## Description
Crawling DISA publications for Instructions at https://disa.mil/About/DISA-Issuances/Instructions and Circulars at https://disa.mil/About/DISA-Issuances/Circulars.

At the time of this PR there are 42 Instructions available and 6 Circulars, all of which are picked up by this crawler.

I also wanted to introduce some refactoring starting in this PR. My goal is to move the logic that is consistent between crawlers into a separate class called DocItemFields. This can hold the data that is used in a consistent way across crawlers. This will allow new crawlers to contain only the aspects that make them unique (crawler name, site scraping logic, urls, etc.).

Also included in this PR is a new PR template and an update to run the github workflows when merging to main as that is the default branch. 

## Result of Crawler Run on Dev
```yaml
 DISA_pubs
        Required CAC: 0
        In Previous Hashes: 0
        Item Scraped Count: 48
        Elapsed Time (sec): 6.68043
        Close Reason: finished
```
## Example Metadata
```javascript
{
    "doc_name": "DISAC 270-A85-1",
    "doc_title": "System Equipment Reporting System (SERS)",
    "doc_num": "270-A85-1",
    "doc_type": "Circular",
    "display_doc_type": "Circular",
    "publication_date": "2017-03-17T00:00:00",
    "cac_login_required": false,
    "crawler_used": "DISA_pubs",
    "downloadable_items": [
        {
            "doc_type": "pdf",
            "download_url": "https://disa.mil/-/media/Files/DISA/About/Publication/Circular/270-A85-1-System-Equipment-Reporting-System.pdf",
            "compression_type": null
        }
    ],
    "source_page_url": "https://disa.mil/About/DISA-Issuances/Circulars",
    "source_fqdn": "disa.mil",
    "download_url": "https://disa.mil/-/media/Files/DISA/About/Publication/Circular/270-A85-1-System-Equipment-Reporting-System.pdf",
    "version_hash_raw_data": {
        "doc_name": "DISAC 270-A85-1",
        "doc_num": "270-A85-1",
        "publication_date": "2017-03-17T00:00:00",
        "download_url": "https://disa.mil/-/media/Files/DISA/About/Publication/Circular/270-A85-1-System-Equipment-Reporting-System.pdf",
        "display_title": "System Equipment Reporting System (SERS)"
    },
    "version_hash": "7eea6bdfb53ca2a9244a1039097fcf826a8082a1a8fa66cdbf75f1452a3e6a57",
    "display_org": "Defense Information Systems Agency",
    "data_source": "Defense Information Systems Agency",
    "source_title": "DISA Policy/Issuances",
    "display_source": "Defense Information Systems Agency - DISA Policy/Issuances",
    "display_title": "DISAC 270-A85-1: System Equipment Reporting System (SERS)",
    "file_ext": "pdf",
    "is_revoked": false,
    "access_timestamp": "2024-04-29T14:05:05"
}
```