### PR TITLE
New UFC Spider

### DIFF
--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/ufc_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/ufc_spider.py
@@ -147,12 +147,17 @@ class UFCSpider(GCSpider):
                 download_url = url
         if download_url == "":
             return None
+        
+        doc_type = "UFC"
+        if "unified-facilities-guide-specifications-ufgs" in response.url:
+            doc_type = "UFGS"
 
         fields = DocItemFields(
             doc_name=full_title,
             doc_title=self.ascii_clean(doc_title),
             doc_num=doc_num,
-            doc_type="Document",
+            doc_type=doc_type,
+            display_doc_type="Document",
             publication_date=parse_timestamp(publication_date),
             cac_login_required=False,
             source_page_url=response.url,
@@ -250,8 +255,9 @@ class UFCSpider(GCSpider):
                 fields = DocItemFields(
                     doc_name=doc_name,
                     doc_title=doc_title,
-                    doc_num=" ",
-                    doc_type="Document",
+                    doc_num="2-000-05N",
+                    doc_type="UFC",
+                    display_doc_type="Document",
                     publication_date=parse_timestamp(publication_date),
                     cac_login_required=False,
                     source_page_url=response.url,

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/ufc_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/ufc_spider.py
@@ -11,9 +11,11 @@ from dataPipelines.gc_scrapy.gc_scrapy.GCSpider import GCSpider
 
 class UFCSpider(GCSpider):
     """
-    As of 05/29/2024
-    crawls https://www.wbdg.org/ffc/dod/unified-facilities-criteria-ufc for 186 pdfs (doc_type = Document)
-    crawls https://www.wbdg.org/ffc/dod/unified-facilities-guide-specifications-ufgs for 762 pdfs (doc_type = Document)
+    As of 06/06/2024
+    crawls https://wbdg.org/ffc/dod/unified-facilities-criteria-ufc for 168 pdfs (doc_type = Document) &
+    crawls https://wbdg.org/ffc/dod/unified-facilities-criteria-ufc/fc-2-000-05n for 18 pdfs (doc_type = Document) &
+    crawls https://wbdg.org/ffc/dod/unified-facilities-guide-specifications-ufgs for 695 pdfs (doc_type = Document) &
+    crawls https://wbdg.org/ffc/dod/unified-facilities-guide-specifications-ufgs/ufgs-changes-revisions for 67 pdfs (doc_type = Document) that are not in the main table
     """
 
     # Crawler name
@@ -243,7 +245,7 @@ class UFCSpider(GCSpider):
 
                 doc_title = doc_name
                 if "FC 2-000-05N" not in doc_title:
-                    doc_title = "FC 2-000-05N: " + doc_title 
+                    doc_title = "FC 2-000-05N: " + doc_title
 
                 fields = DocItemFields(
                     doc_name=doc_name,

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/ufc_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/ufc_spider.py
@@ -12,8 +12,8 @@ from dataPipelines.gc_scrapy.gc_scrapy.GCSpider import GCSpider
 class UFCSpider(GCSpider):
     """
     As of 05/29/2024
-    crawls https://www.wbdg.org/ffc/dod/unified-facilities-criteria-ufc for 168 pdfs (doc_type = Document)
-    crawls https://www.wbdg.org/ffc/dod/unified-facilities-guide-specifications-ufgs for 168 pdfs (doc_type = Document)
+    crawls https://www.wbdg.org/ffc/dod/unified-facilities-criteria-ufc for 169 pdfs (doc_type = Document)
+    crawls https://www.wbdg.org/ffc/dod/unified-facilities-guide-specifications-ufgs for 762 pdfs (doc_type = Document)
     """
 
     # Crawler name

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/ufc_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/ufc_spider.py
@@ -56,7 +56,12 @@ class UFCSpider(GCSpider):
                     full_title = cells[0].get_text().strip()
                     doc_num = full_title.split(" ")[1]
                     doc_title = " ".join(full_title.split(" ")[2:])
-                    publication_date = parse_timestamp(cells[1].get_text().strip())
+                    date = cells[1].get_text().strip()
+                    change_date = cells[2].get_text().strip()
+                    if change_date != "":
+                        publication_date = parse_timestamp(change_date)
+                    else:
+                        publication_date = parse_timestamp(date)
                     url = cells[3].find("a").get("href")
                 except AttributeError as e:
                     print(e)

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/ufc_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/ufc_spider.py
@@ -1,0 +1,103 @@
+from typing import Any, Generator
+from urllib.parse import urljoin
+import bs4
+import scrapy
+
+from dataPipelines.gc_scrapy.gc_scrapy.utils import parse_timestamp
+from dataPipelines.gc_scrapy.gc_scrapy.doc_item_fields import DocItemFields
+from dataPipelines.gc_scrapy.gc_scrapy.items import DocItem
+from dataPipelines.gc_scrapy.gc_scrapy.GCSpider import GCSpider
+
+
+class UFCSpider(GCSpider):
+    """
+    As of 05/29/2024
+    crawls https://www.wbdg.org/ffc/dod/unified-facilities-criteria-ufc for 168 pdfs (doc_type = Document)
+    """
+
+    # Crawler name
+    name = "UFC"
+    # Level 1: GC app 'Source' filter for docs from this crawler
+    display_org = "Department of Defense"
+    # Level 2: GC app 'Source' metadata field for docs from this crawler
+    data_source = "Whole Building Design Guide"
+    # Level 3 filter
+    source_title = "Unified Facilities Criteria"
+
+    domain = "wbdg.org"
+    base_url = f"https://{domain}"
+    allowed_domains = [domain]
+    start_urls = [urljoin(base_url, "/ffc/dod/unified-facilities-criteria-ufc")]
+
+    rotate_user_agent = True
+    date_format = "%m/%d/%y"
+
+    def parse(self, response: scrapy.http.Response) -> Generator[DocItem, Any, None]:
+        """Parses UFC doc items out of Whole Building Design Guide site"""
+        page_url = response.url
+        yield scrapy.Request(
+            url=page_url, callback=self.parse_table, meta={"page_id": 0}
+        )
+
+    def parse_table(
+        self, response: scrapy.http.Response
+    ) -> Generator[DocItem, Any, None]:
+        """Recursively parses each table in the main content"""
+        page_id = response.meta["page_id"]
+        soup = bs4.BeautifulSoup(
+            response.xpath('//*[@id="block-system-main"]/div').get(),
+            features="html.parser",
+        )
+        table_body = soup.find("tbody")
+
+        if table_body is not None:
+            for row in table_body.find_all("tr"):
+
+                cells = row.find_all("td")
+
+                try:
+                    full_title = cells[0].get_text().strip()
+                    acronym = full_title.split(" ")[0]
+                    doc_num = full_title.split(" ")[1]
+                    doc_title = " ".join(full_title.split(" ")[2:])
+                    publication_date = parse_timestamp(cells[1].get_text().strip())
+                    url = cells[3].find("a").get("href")
+                except AttributeError as e:
+                    print(e)
+                    continue
+
+                fields = DocItemFields(
+                    doc_name=full_title,
+                    doc_title=self.ascii_clean(doc_title),
+                    doc_num=doc_num,
+                    doc_type=self.get_doc_type(acronym),
+                    publication_date=publication_date,
+                    cac_login_required=False,
+                    source_page_url=url,
+                    downloadable_items=[
+                        {"doc_type": "pdf", "download_url": url, "compression_type": None}
+                    ],
+                    download_url=url,
+                    file_ext="pdf",
+                )
+                fields.set_display_name(full_title)
+
+                yield fields.populate_doc_item(
+                    display_org=self.display_org,
+                    data_source=self.data_source,
+                    source_title=self.source_title,
+                    crawler_used=self.name,
+                )
+
+            page_id += 1
+            yield scrapy.Request(
+                url=urljoin(self.start_urls[0], f"?page={page_id}"),
+                callback=self.parse_table,
+                meta={"page_id": page_id},
+            )
+
+    def get_doc_type(self, doc_name: str) -> str:
+        """Takes in the doc name and returns the type, only handles DISAC and DISAI docs"""
+        if "FC" in doc_name:
+            return "Document"
+        raise ValueError(f"Unexpected value for doc_name {doc_name}")

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/ufc_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/ufc_spider.py
@@ -213,10 +213,12 @@ class UFCSpider(GCSpider):
         self, response: scrapy.http.Response
     ) -> Generator[DocItem, Any, None]:
         """
-        Parses docs from table in 
+        Parses docs from table in
         https://wbdg.org/ffc/dod/unified-facilities-criteria-ufc/fc-2-000-05n
         """
-        content = response.xpath('//*[@id="node-6064"]/div/div/div[3]/div/div/table').get()
+        content = response.xpath(
+            '//*[@id="node-6064"]/div/div/div[3]/div/div/table'
+        ).get()
         if content is None:
             return None
         soup = bs4.BeautifulSoup(
@@ -227,14 +229,14 @@ class UFCSpider(GCSpider):
 
         if table_body is not None:
             for row in table_body.find_all("tr"):
-                
+
                 try:
                     cells = row.find_all("td")
                     doc_title = self.ascii_clean(cells[0].get_text().strip())
                     publication_date = cells[1].get_text().strip()
-                    download_url = urljoin(self.base_url, cells[2].find("a").get("href"))
-
-                    print(f"doc_title: {doc_title} | publication_date: {publication_date} | download_url: {download_url}")
+                    download_url = urljoin(
+                        self.base_url, cells[2].find("a").get("href")
+                    )
                 except IndexError as e:
                     print(e)
                     continue

--- a/dataPipelines/gc_scrapy/gc_scrapy/spiders/ufc_spider.py
+++ b/dataPipelines/gc_scrapy/gc_scrapy/spiders/ufc_spider.py
@@ -13,6 +13,7 @@ class UFCSpider(GCSpider):
     """
     As of 05/29/2024
     crawls https://www.wbdg.org/ffc/dod/unified-facilities-criteria-ufc for 168 pdfs (doc_type = Document)
+    crawls https://www.wbdg.org/ffc/dod/unified-facilities-guide-specifications-ufgs for 168 pdfs (doc_type = Document)
     """
 
     # Crawler name
@@ -27,7 +28,10 @@ class UFCSpider(GCSpider):
     domain = "wbdg.org"
     base_url = f"https://{domain}"
     allowed_domains = [domain]
-    start_urls = [urljoin(base_url, "/ffc/dod/unified-facilities-criteria-ufc")]
+    start_urls = [
+        urljoin(base_url, "/ffc/dod/unified-facilities-criteria-ufc"),
+        urljoin(base_url, "/ffc/dod/unified-facilities-guide-specifications-ufgs"),
+    ]
 
     def parse(self, response: scrapy.http.Response) -> Generator[DocItem, Any, None]:
         """Parses UFC doc items out of Whole Building Design Guide site"""
@@ -40,6 +44,7 @@ class UFCSpider(GCSpider):
         self, response: scrapy.http.Response
     ) -> Generator[DocItem, Any, None]:
         """Recursively parses each table in the main content"""
+        page_url = response.url
         page_id = response.meta["page_id"]
         soup = bs4.BeautifulSoup(
             response.xpath('//*[@id="block-system-main"]/div').get(),
@@ -51,52 +56,212 @@ class UFCSpider(GCSpider):
             for row in table_body.find_all("tr"):
 
                 cells = row.find_all("td")
-
-                try:
-                    full_title = cells[0].get_text().strip()
-                    doc_num = full_title.split(" ")[1]
-                    doc_title = " ".join(full_title.split(" ")[2:])
-                    date = cells[1].get_text().strip()
-                    change_date = cells[2].get_text().strip()
-                    if change_date != "":
-                        publication_date = parse_timestamp(change_date)
+                doc_url = cells[0].find("a").get("href")
+                if doc_url:
+                    if "fc-2-000-05n" in doc_url:
+                        yield scrapy.Request(
+                            url=urljoin(self.base_url, doc_url),
+                            callback=self.parse_fc_2,
+                        )
+                    if "ufgs-changes-and-revisions" in doc_url:
+                        yield scrapy.Request(
+                            url=urljoin(self.base_url, doc_url),
+                            callback=self.parse_changes_revisions,
+                            meta={"page_id": 0},
+                        )
                     else:
-                        publication_date = parse_timestamp(date)
-                    url = cells[3].find("a").get("href")
-                except AttributeError as e:
-                    print(e)
-                    continue
+                        yield scrapy.Request(
+                            url=urljoin(self.base_url, doc_url),
+                            callback=self.parse_doc_page,
+                        )
 
-                fields = DocItemFields(
-                    doc_name=full_title,
-                    doc_title=self.ascii_clean(doc_title),
-                    doc_num=doc_num,
-                    doc_type="Document",
-                    publication_date=publication_date,
-                    cac_login_required=False,
-                    source_page_url=url,
-                    downloadable_items=[
-                        {
-                            "doc_type": "pdf",
-                            "download_url": url,
-                            "compression_type": None,
-                        }
-                    ],
-                    download_url=url,
-                    file_ext="pdf",
-                )
-                fields.set_display_name(full_title)
+            page_id += 1
+            url = page_url.split("?")[0]
+            yield scrapy.Request(
+                url=urljoin(url, f"?page={page_id}"),
+                callback=self.parse_table,
+                meta={"page_id": page_id},
+            )
 
-                yield fields.populate_doc_item(
-                    display_org=self.display_org,
-                    data_source=self.data_source,
-                    source_title=self.source_title,
-                    crawler_used=self.name,
+    def parse_doc_page(
+        self, response: scrapy.http.Response
+    ) -> Generator[DocItem, Any, None]:
+        """Get doc data from doc's page instead of table"""
+        soup = bs4.BeautifulSoup(
+            response.xpath('//*[@id="main"]').get(),
+            features="html.parser",
+        )
+        full_title = soup.find("h1").get_text().strip()
+        split_title = full_title.split(" ")
+        acronym = split_title[0].strip()
+        if acronym in ["FC", "UFC"]:
+            doc_num = split_title[1]
+            doc_title = " ".join(split_title[2:])
+        # Added split_title[1].isdigit() to send UFGS Master to else statement
+        elif acronym == "UFGS" and split_title[1].isdigit():
+            title_start_idx = 4
+            if split_title[title_start_idx].isdigit():
+                title_start_idx = 5
+            doc_num = " ".join(split_title[1:title_start_idx])
+            doc_title = " ".join(split_title[title_start_idx:])
+        else:
+            doc_num = " "
+            doc_title = full_title
+
+        soup = bs4.BeautifulSoup(
+            response.xpath(
+                '//*[(@id = "block-system-main")]//*[contains(concat( " ", @class, " " ), concat( " ", "content", " " ))] '
+            ).get(),
+            features="html.parser",
+        )
+
+        date_div = soup.find("div", text="Date: ")
+        publication_date = None
+        if date_div:
+            publication_date = date_div.find_next_sibling("div").get_text().strip()
+
+        change_date_div = soup.find("div", text="Change / Revision Date: ")
+        if change_date_div:
+            publication_date = (
+                change_date_div.find_next_sibling("div").get_text().strip()
+            )
+
+        status_div = soup.find("div", text="Status: ")
+        status = "Active"
+        if status_div:
+            status = status_div.find_next_sibling("div").get_text().strip()
+            if status == "Inactive":
+                return None
+
+        download_div = soup.find("div", text="View/Download: ")
+        if not download_div:
+            return None
+
+        links = download_div.find_next_sibling("div").find_all("a")
+        download_url = ""
+        for link in links:
+            url = link.get("href")
+            if url.endswith(".pdf"):
+                download_url = url
+        if download_url == "":
+            return None
+
+        fields = DocItemFields(
+            doc_name=full_title,
+            doc_title=self.ascii_clean(doc_title),
+            doc_num=doc_num,
+            doc_type="Document",
+            publication_date=parse_timestamp(publication_date),
+            cac_login_required=False,
+            source_page_url=response.url,
+            downloadable_items=[
+                {
+                    "doc_type": "pdf",
+                    "download_url": download_url,
+                    "compression_type": None,
+                }
+            ],
+            download_url=download_url,
+            file_ext="pdf",
+        )
+        fields.set_display_name(full_title)
+
+        yield fields.populate_doc_item(
+            display_org=self.display_org,
+            data_source=self.data_source,
+            source_title=self.source_title,
+            crawler_used=self.name,
+        )
+
+    def parse_changes_revisions(
+        self, response: scrapy.http.Response
+    ) -> Generator[DocItem, Any, None]:
+        """
+        Find all urls in the table from
+        https://wbdg.org/ffc/dod/unified-facilities-guide-specifications-ufgs/ufgs-changes-revisions
+        """
+        page_url = response.url
+        page_id = response.meta["page_id"]
+        content = response.xpath('//*[@id="block-system-main"]/div/div/div[3]').get()
+        if content is None:
+            return None
+        soup = bs4.BeautifulSoup(
+            content,
+            features="html.parser",
+        )
+        table_body = soup.find("tbody")
+
+        if table_body is not None:
+            for row in table_body.find_all("tr"):
+
+                cells = row.find_all("td")
+                doc_url = cells[2].find("a").get("href")
+                yield scrapy.Request(
+                    url=urljoin(self.base_url, doc_url),
+                    callback=self.parse_doc_page,
                 )
 
             page_id += 1
+            url = page_url.split("?")[0]
             yield scrapy.Request(
-                url=urljoin(self.start_urls[0], f"?page={page_id}"),
-                callback=self.parse_table,
+                url=urljoin(url, f"?page={page_id}"),
+                callback=self.parse_changes_revisions,
                 meta={"page_id": page_id},
+            )
+
+    def parse_fc_2(
+        self, response: scrapy.http.Response
+    ) -> Generator[DocItem, Any, None]:
+        """
+        Parses docs from table in 
+        https://wbdg.org/ffc/dod/unified-facilities-criteria-ufc/fc-2-000-05n
+        """
+        content = response.xpath('//*[@id="node-6064"]/div/div/div[3]/div/div/table').get()
+        if content is None:
+            return None
+        soup = bs4.BeautifulSoup(
+            content,
+            features="html.parser",
+        )
+        table_body = soup.find("tbody")
+
+        if table_body is not None:
+            for row in table_body.find_all("tr"):
+                
+                try:
+                    cells = row.find_all("td")
+                    doc_title = self.ascii_clean(cells[0].get_text().strip())
+                    publication_date = cells[1].get_text().strip()
+                    download_url = urljoin(self.base_url, cells[2].find("a").get("href"))
+
+                    print(f"doc_title: {doc_title} | publication_date: {publication_date} | download_url: {download_url}")
+                except IndexError as e:
+                    print(e)
+                    continue
+
+            fields = DocItemFields(
+                doc_name=doc_title,
+                doc_title=doc_title,
+                doc_num=" ",
+                doc_type="Document",
+                publication_date=parse_timestamp(publication_date),
+                cac_login_required=False,
+                source_page_url=response.url,
+                downloadable_items=[
+                    {
+                        "doc_type": "pdf",
+                        "download_url": download_url,
+                        "compression_type": None,
+                    }
+                ],
+                download_url=download_url,
+                file_ext="pdf",
+            )
+            fields.set_display_name(doc_title)
+
+            yield fields.populate_doc_item(
+                display_org=self.display_org,
+                data_source=self.data_source,
+                source_title=self.source_title,
+                crawler_used=self.name,
             )

--- a/paasJobs/crawler_schedule/monday.txt
+++ b/paasJobs/crawler_schedule/monday.txt
@@ -3,3 +3,4 @@ chief_national_guard_bureau_spider.py
 ic_policies_spider.py
 stig_spider.py
 tradoc_spider.py
+ufc_spider.py


### PR DESCRIPTION
## Description
Adding a new spider to crawl the documents from https://www.wbdg.org/ffc/dod/unified-facilities-criteria-ufc & https://www.wbdg.org/ffc/dod/unified-facilities-guide-specifications-ufgs. For both start urls the part of the site that we want to scrape is a table. It was originally thought that we would have to use the Selenium spider to interact with the table navigation, but I found that we can move through the table pages by manipulating the URLs. For each table entry we visit its linked page to get the metadata and the URL to the pdf.

All of the documents have been assigned doc_type = "Document". 

There are two possible dates for each document "Date" and "Revision Date", since "Date" is present on every row I decided to use this as the publication_date.

Two pages required specialized scraping functions
- https://wbdg.org/ffc/dod/unified-facilities-criteria-ufc/fc-2-000-05n
- https://wbdg.org/ffc/dod/unified-facilities-guide-specifications-ufgs/ufgs-changes-and-revisions

## Result of Crawler Run on Dev
```yaml 
 UFC
        Required CAC: 0
        In Previous Hashes: 0
        Item Scraped Count: 948
        Elapsed Time (sec): 418.37702
        Close Reason: finished
```

## Example Metadata
```javascript 
{
      "doc_name": "UFGS 06 20 00 Finish Carpentry",
      "doc_title": "Finish Carpentry",
      "doc_num": "06 20 00",
      "doc_type": "Document",
      "display_doc_type": "Document",
      "publication_date": "2016-08-01T00:00:00",
      "cac_login_required": false,
      "crawler_used": "UFC",
      "downloadable_items": [
          {
              "doc_type": "pdf",
              "download_url": "https://wbdg.org/FFC/DOD/UFGS/UFGS%2006%2020%2000.pdf",
              "compression_type": null
          }
      ],
      "source_page_url": "https://wbdg.org/ffc/dod/unified-facilities-guide-specifications-ufgs/ufgs-06-20-00",
      "source_fqdn": "wbdg.org",
      "download_url": "https://wbdg.org/FFC/DOD/UFGS/UFGS%2006%2020%2000.pdf",
      "version_hash_raw_data": {
          "doc_name": "UFGS 06 20 00 Finish Carpentry",
          "doc_num": "06 20 00",
          "publication_date": "2016-08-01T00:00:00",
          "download_url": "https://wbdg.org/FFC/DOD/UFGS/UFGS%2006%2020%2000.pdf",
          "display_title": "UFGS 06 20 00 Finish Carpentry"
      },
      "version_hash": "5ac18243bd338129f21607e2aa7b1b6ef092fb8b5b8353a3e686505fe03200f0",
      "display_org": "Department of Defense",
      "data_source": "Whole Building Design Guide",
      "source_title": "Unified Facilities Criteria",
      "display_source": "Whole Building Design Guide - Unified Facilities Criteria",
      "display_title": "UFGS 06 20 00 Finish Carpentry",
      "file_ext": "pdf",
      "is_revoked": false,
      "access_timestamp": "2024-06-06T17:59:19"
  }
```