### PR TITLE
Update Centos Mirror List 

### DIFF
--- a/docker/core/Dockerfile
+++ b/docker/core/Dockerfile
@@ -13,6 +13,10 @@ SHELL ["/bin/bash", "-c"]
 # LOCALE (important for python, etc.)
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+
 ENV LANG="en_US.UTF-8"
 ENV LANGUAGE="en_US.UTF-8"
 ENV LC_CTYPE="en_US.UTF-8"

--- a/docker/core/Dockerfile
+++ b/docker/core/Dockerfile
@@ -13,6 +13,7 @@ SHELL ["/bin/bash", "-c"]
 # LOCALE (important for python, etc.)
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 
+# Update mirrors due to Centos7 EOL
 RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
 RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
 RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo


### PR DESCRIPTION
Centos7 is past it's EOL of June 30th, 2024 https://www.redhat.com/en/topics/linux/centos-linux-eol. Because of this the regular mirrors are no longer online. I followed this thread https://serverfault.com/questions/1161816/mirrorlist-centos-org-no-longer-resolve to update the repo files to point to what is essentially an archival mirror. Definitely will need to upgrade from Centos7 in the near future. 

The error below was being thrown during the `yum update && yum install ...` step
```yaml
Could not retrieve mirrorlist http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=os&infra=container error was
14: curl#6 - "Could not resolve host: mirrorlist.centos.org; Unknown error"


 One of the configured repositories failed (Unknown),
 and yum doesn't have enough cached data to continue. At this point the only
 safe thing yum can do is fail. There are a few ways to work "fix" this:

     1. Contact the upstream for the repository and get them to fix the problem.

     2. Reconfigure the baseurl/etc. for the repository, to point to a working
        upstream. This is most often useful if you are using a newer
        distribution release than is supported by the repository (and the
        packages for the previous distribution release still work).

     3. Run the command with the repository temporarily disabled
            yum --disablerepo=<repoid> ...

     4. Disable the repository permanently, so yum won't use it by default. Yum
        will then just ignore the repository until you permanently enable it
        again or use --enablerepo for temporary usage:

            yum-config-manager --disable <repoid>
        or
            subscription-manager repos --disable=<repoid>

     5. Configure the failing repository to be skipped, if it is unavailable.
        Note that yum will try to contact the repo. when it runs most commands,
        so will have to try and fail each time (and thus. yum will be be much
        slower). If it is a very temporary problem though, this is often a nice
        compromise:

            yum-config-manager --save --setopt=<repoid>.skip_if_unavailable=true

Cannot find a valid baseurl for repo: base/7/x86_64
```