### PR TITLE
Update AWS command in job_runner

### DIFF
--- a/paasJobs/job_runner.sh
+++ b/paasJobs/job_runner.sh
@@ -47,7 +47,7 @@ function upload_logs() {
     local local_log_path="$1"
     local s3_log_path="$2"
 
-    ${AWS_CMD:-aws} s3 cp "$local_log_path" "$s3_log_path"
+    ${AWS_CMD:-/usr/local/bin/aws} s3 cp "$local_log_path" "$s3_log_path"
     return "$?"
   else
     >&2 echo "[SKIPPING] Uploading logs ..."


### PR DESCRIPTION
In the [previous PR ](https://github.com/dod-advana/gamechanger-crawlers/pull/238) we started calling the AWS CLI executable directly. I wanted to apply this throughout the code base to avoid potential issues in the future.